### PR TITLE
feat(parser): add YAML frontmatter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The extension currently supports **13 markdown features** with syntax hiding. Fo
 
 ### Configuration
 - [x] **Show Raw Markdown in Diffs** • [Details](docs/features/show-raw-markdown-in-diffs.md) • [Issue #20](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/20)
+- [x] **Show Raw Markdown in Editor** • [Details](docs/features/show-raw-markdown-in-editor.md)
+
 
 ## Upcoming Features
 
@@ -86,6 +88,7 @@ The extension currently supports **13 markdown features** with syntax hiding. Fo
 - [ ] **YAML Frontmatter** • [Details](docs/features/yaml-frontmatter.md) • [Issue #27](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/27)
 
 ### High Priority
+- [ ] **Set Default Feature Activation** – Allow users to configure which Markdown features are decorated/enabled by default (e.g., selectively apply decorators for headings, bold, italic, etc.) • [Details](docs/features/default-feature-activation.md) • [Issue #33](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/33)
 - [ ] **Tables** • [Details](docs/features/tables.md) • [Issue #23](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/23)
 - [ ] **Autolinks** • [Details](docs/features/autolinks.md) • [Issue #24](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/24)
 - [ ] **Mermaid Diagrams** • [Details](docs/features/mermaid-diagrams.md) • [Issue #26](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/26)

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -87,6 +87,21 @@ export function CodeBlockDecorationType() {
 }
 
 /**
+ * Creates a decoration type for YAML frontmatter styling.
+ * 
+ * Highlights the entire frontmatter block (including --- delimiters) with a background color,
+ * similar to code blocks. The delimiters remain visible.
+ * 
+ * @returns {vscode.TextEditorDecorationType} A decoration type for frontmatter blocks
+ */
+export function FrontmatterDecorationType() {
+  return window.createTextEditorDecorationType({
+    backgroundColor: new ThemeColor('textCodeBlock.background'),
+    isWholeLine: true, // Extend background to full line width
+  });
+}
+
+/**
  * Creates a decoration type for heading styling.
  * 
  * @returns {vscode.TextEditorDecorationType} A decoration type for headings

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -21,6 +21,7 @@ import {
   HorizontalRuleDecorationType,
   CheckboxUncheckedDecorationType,
   CheckboxCheckedDecorationType,
+  FrontmatterDecorationType,
 } from './decorations';
 import { MarkdownParser, DecorationRange, DecorationType } from './parser';
 
@@ -96,6 +97,7 @@ export class Decorator {
   private horizontalRuleDecorationType = HorizontalRuleDecorationType();
   private checkboxUncheckedDecorationType = CheckboxUncheckedDecorationType();
   private checkboxCheckedDecorationType = CheckboxCheckedDecorationType();
+  private frontmatterDecorationType = FrontmatterDecorationType();
 
   /**
    * Sets the active text editor and immediately updates decorations.
@@ -627,6 +629,7 @@ export class Decorator {
     ['horizontalRule', this.horizontalRuleDecorationType],
     ['checkboxUnchecked', this.checkboxUncheckedDecorationType],
     ['checkboxChecked', this.checkboxCheckedDecorationType],
+    ['frontmatter', this.frontmatterDecorationType],
   ]);
 
   /**

--- a/src/parser/__tests__/parser-frontmatter.test.ts
+++ b/src/parser/__tests__/parser-frontmatter.test.ts
@@ -1,0 +1,367 @@
+import { MarkdownParser } from '../../parser';
+import { createCRLFText } from './helpers/crlf-helpers';
+
+describe('MarkdownParser - YAML Frontmatter', () => {
+  let parser: MarkdownParser;
+
+  beforeEach(async () => {
+    parser = await MarkdownParser.create();
+  });
+
+  describe('basic frontmatter detection', () => {
+    it('should detect basic frontmatter with opening and closing delimiters', () => {
+      const markdown = `---
+title: My Document
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      if (frontmatterDec) {
+        expect(frontmatterDec.startPos).toBe(0);
+        expect(frontmatterDec.endPos).toBe(markdown.length);
+      }
+    });
+
+    it('should detect frontmatter with multiple fields', () => {
+      const markdown = `---
+title: Document
+author: Author
+date: 2024-01-01
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      if (frontmatterDec) {
+        expect(frontmatterDec.startPos).toBe(0);
+        expect(frontmatterDec.endPos).toBe(markdown.length);
+      }
+    });
+
+    it('should detect frontmatter at document start with leading whitespace', () => {
+      const markdown = `   ---
+title: Document
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      if (frontmatterDec) {
+        // Should start from the --- (after whitespace)
+        expect(frontmatterDec.startPos).toBe(3);
+        expect(frontmatterDec.endPos).toBe(markdown.length);
+      }
+    });
+
+    it('should not treat frontmatter with leading newlines as frontmatter', () => {
+      const markdown = `\n\n---
+title: Document
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      // Frontmatter must be at document start (only spaces/tabs allowed before it)
+      // Leading newlines mean it's not at the start, so it shouldn't be treated as frontmatter
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+    });
+
+    it('should detect empty frontmatter', () => {
+      const markdown = `---
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      if (frontmatterDec) {
+        expect(frontmatterDec.startPos).toBe(0);
+        expect(frontmatterDec.endPos).toBe(markdown.length);
+      }
+    });
+
+    it('should detect frontmatter with only whitespace', () => {
+      const markdown = `---
+   
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      if (frontmatterDec) {
+        expect(frontmatterDec.startPos).toBe(0);
+        expect(frontmatterDec.endPos).toBe(markdown.length);
+      }
+    });
+  });
+
+  describe('frontmatter edge cases', () => {
+    it('should not treat --- in middle of document as frontmatter', () => {
+      const markdown = `# Heading
+---
+This is a horizontal rule
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      // Should not have frontmatter decoration
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+      
+      // Should have horizontal rule decorations instead
+      expect(result.some(d => d.type === 'horizontalRule')).toBe(true);
+    });
+
+    it('should not treat --- after newline and content as frontmatter', () => {
+      const markdown = `# Heading
+---
+title: Document
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      // Should not have frontmatter decoration (--- is after content, not at start)
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+    });
+
+    it('should not treat invalid closing delimiter format as frontmatter', () => {
+      const markdown = `---
+title: Document
+--- some text`;
+      const result = parser.extractDecorations(markdown);
+
+      // Should not have frontmatter decoration (closing delimiter has extra text)
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+    });
+
+    it('should not treat ---comment as closing delimiter', () => {
+      const markdown = `---
+title: Document
+---comment`;
+      const result = parser.extractDecorations(markdown);
+
+      // Should not have frontmatter decoration (closing delimiter has text after ---)
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+    });
+
+    it('should not apply decoration for incomplete frontmatter (no closing delimiter)', () => {
+      const markdown = `---
+title: Document
+# Content starts here`;
+      const result = parser.extractDecorations(markdown);
+
+      // Should not have frontmatter decoration
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+    });
+
+    it('should handle frontmatter followed by content', () => {
+      const markdown = `---
+title: Document
+---
+# Content starts here`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      if (frontmatterDec) {
+        // Should only cover the frontmatter block, not the content
+        expect(frontmatterDec.endPos).toBeLessThan(markdown.length);
+        // Should end at the closing --- (not including the newline after it)
+        expect(markdown.substring(frontmatterDec.endPos - 3, frontmatterDec.endPos)).toBe('---');
+      }
+    });
+
+    it('should handle frontmatter followed by horizontal rule', () => {
+      const markdown = `---
+title: Document
+---
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      // Should have frontmatter decoration
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      // Should also have horizontal rule decoration for the second ---
+      expect(result.some(d => d.type === 'horizontalRule')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      const horizontalRuleDec = result.find(d => d.type === 'horizontalRule');
+      
+      expect(frontmatterDec).toBeDefined();
+      expect(horizontalRuleDec).toBeDefined();
+      
+      if (frontmatterDec && horizontalRuleDec) {
+        // Frontmatter should end before horizontal rule starts
+        expect(frontmatterDec.endPos).toBeLessThanOrEqual(horizontalRuleDec.startPos);
+      }
+    });
+  });
+
+  describe('position accuracy', () => {
+    it('should have correct positions for frontmatter with content', () => {
+      const markdown = `---
+title: My Document
+author: John Doe
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      
+      if (frontmatterDec) {
+        expect(frontmatterDec.startPos).toBeGreaterThanOrEqual(0);
+        expect(frontmatterDec.endPos).toBeLessThanOrEqual(markdown.length);
+        expect(frontmatterDec.endPos).toBeGreaterThan(frontmatterDec.startPos);
+        
+        // Verify it starts with ---
+        expect(markdown.substring(frontmatterDec.startPos, frontmatterDec.startPos + 3)).toBe('---');
+        
+        // Verify it ends with --- (check the last 3 characters before the end position)
+        // Account for possible newline after closing delimiter
+        const endCheckStart = frontmatterDec.endPos >= 3 ? frontmatterDec.endPos - 3 : 0;
+        const endCheckEnd = frontmatterDec.endPos;
+        const endingText = markdown.substring(endCheckStart, endCheckEnd);
+        expect(endingText).toContain('---');
+      }
+    });
+
+    it('should have valid positions for all decorations when frontmatter is present', () => {
+      const markdown = `---
+title: Document
+---
+# Heading with **bold** text`;
+      const result = parser.extractDecorations(markdown);
+
+      // All positions should be valid
+      result.forEach(dec => {
+        expect(dec.startPos).toBeGreaterThanOrEqual(0);
+        expect(dec.endPos).toBeLessThanOrEqual(markdown.length);
+        expect(dec.endPos).toBeGreaterThan(dec.startPos);
+      });
+      
+      // Positions should be sorted
+      for (let i = 1; i < result.length; i++) {
+        expect(result[i].startPos).toBeGreaterThanOrEqual(result[i - 1].startPos);
+      }
+    });
+  });
+
+  describe('interaction with other features', () => {
+    it('should work with headings after frontmatter', () => {
+      const markdown = `---
+title: Document
+---
+# Heading`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      expect(result.some(d => d.type === 'heading1')).toBe(true);
+    });
+
+    it('should work with bold text in content after frontmatter', () => {
+      const markdown = `---
+title: Document
+---
+Content with **bold** text`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      expect(result.some(d => d.type === 'bold')).toBe(true);
+    });
+
+    it('should not interfere with horizontal rules in content', () => {
+      const markdown = `---
+title: Document
+---
+Content above
+
+---
+Content below`;
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      // Should have horizontal rule decoration for the --- in content
+      const horizontalRules = result.filter(d => d.type === 'horizontalRule');
+      expect(horizontalRules.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('frontmatter with CRLF line endings', () => {
+    it('should detect frontmatter with CRLF line endings', () => {
+      const markdown = createCRLFText(`---
+title: Document
+author: Author
+---`);
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      if (frontmatterDec) {
+        expect(frontmatterDec.startPos).toBeGreaterThanOrEqual(0);
+        expect(frontmatterDec.endPos).toBeLessThanOrEqual(markdown.length);
+      }
+    });
+
+    it('should have correct positions for frontmatter with CRLF', () => {
+      const markdown = createCRLFText(`---
+title: My Document
+---`);
+      const result = parser.extractDecorations(markdown);
+
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      expect(frontmatterDec).toBeDefined();
+      
+      if (frontmatterDec) {
+        // Verify positions are valid
+        expect(frontmatterDec.startPos).toBeGreaterThanOrEqual(0);
+        expect(frontmatterDec.endPos).toBeLessThanOrEqual(markdown.length);
+        expect(frontmatterDec.endPos).toBeGreaterThan(frontmatterDec.startPos);
+      }
+    });
+
+    it('should handle frontmatter followed by content with CRLF', () => {
+      const markdown = createCRLFText(`---
+title: Document
+---
+# Content starts here`);
+      const result = parser.extractDecorations(markdown);
+
+      expect(result.some(d => d.type === 'frontmatter')).toBe(true);
+      expect(result.some(d => d.type === 'heading1')).toBe(true);
+      
+      const frontmatterDec = result.find(d => d.type === 'frontmatter');
+      const headingDec = result.find(d => d.type === 'heading1');
+      
+      expect(frontmatterDec).toBeDefined();
+      expect(headingDec).toBeDefined();
+      
+      if (frontmatterDec && headingDec) {
+        // Frontmatter should end before heading starts
+        expect(frontmatterDec.endPos).toBeLessThanOrEqual(headingDec.startPos);
+      }
+    });
+
+    it('should not treat --- after content as frontmatter with CRLF', () => {
+      const markdown = createCRLFText(`# Heading
+---
+This is a horizontal rule`);
+      const result = parser.extractDecorations(markdown);
+
+      // Should not have frontmatter decoration
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+      
+      // Should have horizontal rule decoration instead
+      expect(result.some(d => d.type === 'horizontalRule')).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
- Detect and highlight YAML frontmatter blocks at document start
- Hide delimiters remain visible, entire block highlighted with background color
- Validate closing delimiter format (only --- with optional whitespace)
- Handle edge cases: incomplete frontmatter, invalid formats, content before frontmatter
- Add performance limit (100 lines) for closing delimiter search
- Support CRLF line endings via existing position mapping
- Add comprehensive test coverage (22 tests including CRLF scenarios)
- Integrate with existing decoration system and prevent conflicts with horizontal rules