### PR TITLE
feat(ordered-list): hide markers and replace with auto-calculated sequential numbers

### DIFF
--- a/docs/features/done/ordered-list-auto-numbering.md
+++ b/docs/features/done/ordered-list-auto-numbering.md
@@ -1,0 +1,126 @@
+---
+status: DONE
+updateDate: 2026-03-23
+priority: Low Priority
+---
+
+# Ordered List Auto-Numbering
+
+## Overview
+
+Ordered list markers are hidden and replaced with auto-calculated sequential numbers based on position in the list.
+
+## Implementation
+
+- Syntax: `1.`, `2.`, etc. (dot) or `1)`, `2)`, etc. (parentheses)
+- Original markers are hidden via `display: none`
+- Numbers are auto-calculated from position in the parent list
+- Supports custom start numbers (e.g., `5. item` starts at 5)
+- Supports lazy numbering (all `1.`) — numbers are calculated by position
+- Supports nested ordered lists (each level numbered independently)
+- Both `.` and `)` delimiters are preserved in the replacement
+- Uses per-range `renderOptions.before.contentText` for dynamic replacement text
+- Cursor on a list item reveals the raw markdown marker
+- Ghost-faint rendering on active lines (consistent with other markers)
+
+## Acceptance Criteria
+
+### Basic Auto-Numbering
+```gherkin
+Feature: Ordered list auto-numbering
+
+  Scenario: Sequential markers
+    When I type 1. First\n2. Second\n3. Third
+    Then markers are hidden
+    And numbers 1, 2, 3 are displayed
+
+  Scenario: Lazy numbering (all ones)
+    When I type 1. First\n1. Second\n1. Third
+    Then markers are hidden
+    And numbers 1, 2, 3 are displayed based on position
+
+  Scenario: Parentheses syntax
+    When I type 1) First\n1) Second
+    Then markers are hidden
+    And numbers 1), 2) are displayed
+```
+
+### Nested Lists
+```gherkin
+Feature: Nested ordered list auto-numbering
+
+  Scenario: Single nesting level
+    When I type 1. Outer\n   1. Inner\n   1. Inner
+    Then outer items are numbered 1, 2
+    And inner items are numbered 1, 2 independently
+
+  Scenario: Multiple nesting levels
+    When I type 1. Outer\n   1. Middle\n      1. Inner
+    Then all levels are numbered correctly and independently
+```
+
+### Reveal Raw Markdown
+```gherkin
+Feature: Reveal ordered list raw markdown
+
+  Scenario: Reveal on select
+    Given 1. item is in my file
+    When I select the list item
+    Then the raw markdown marker is shown
+    When I deselect
+    Then the auto-numbered replacement is displayed again
+```
+
+### Edge Cases
+```gherkin
+Feature: Ordered list edge cases
+
+  Scenario: Out-of-order numbering
+    When I type 3. First\n1. Second\n2. Third
+    Then numbers are auto-calculated based on position (3, 4, 5)
+
+  Scenario: Custom start number
+    When a list starts with 5. Item
+    Then numbering begins at 5
+
+  Scenario: Ordered list with checkboxes
+    When I type 1. [ ] Task\n2. [x] Done
+    Then the numbers are auto-calculated
+    And checkboxes are displayed correctly
+```
+
+## Notes
+
+- Uses remark's `List.start` property for custom start numbers
+- Uses `List.children.indexOf(node)` to determine position
+- The `replacement` field on `DecorationRange` is set per-item by the parser
+- Added to `selectionOnlyMarkerTypes` for cursor-reveal behavior
+- Added to `markerDecorationTypes` for ghost-faint rendering
+- Added to `renderOptionsTypes` for per-range `DecorationOptions` handling
+
+## Examples
+
+**Lazy numbering (all `1.`) → auto-numbered by position:**
+```
+1. First    →  1. First
+1. Second   →  2. Second
+1. Third    →  3. Third
+```
+
+**Parentheses delimiter:**
+```
+1) A   →  1) A
+1) B   →  2) B
+```
+
+**Custom start number:**
+```
+5. Start here   →  5. Start here
+1. Next item    →  6. Next item
+```
+
+**With checkboxes:**
+```
+1. [ ] Task 1   →  1. ☐ Task 1
+2. [x] Task 2   →  2. ☑ Task 2
+```

--- a/package.json
+++ b/package.json
@@ -129,6 +129,18 @@
           "description": "Render LaTeX math inline ($...$ and $$...$$)",
           "markdownDescription": "Render LaTeX math inline ($...$ and $$...$$). When disabled, math delimiters are shown as plain text."
         },
+        "markdownInlineEditor.orderedLists.autoNumber": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show computed ordered list numbers instead of the source marker",
+          "markdownDescription": "When enabled, ordered list markers are hidden and replaced with sequential numbers (for example lazy `1.` lists). When disabled, numbers in the file are shown exactly as written. The document on disk is never changed either way."
+        },
+        "markdownInlineEditor.orderedLists.warnWhenSourceNumberDiffers": {
+          "type": "boolean",
+          "default": true,
+          "description": "Highlight when the source marker number differs from the computed number",
+          "markdownDescription": "When ordered list auto-numbering is on, use the warning color for the displayed marker when the number in the source text does not match the computed number (for example all lines use `1.` but the view shows 1., 2., 3.)."
+        },
         "markdownInlineEditor.mentions.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,20 @@ export const config = {
         .get<boolean>('math.enabled', true);
     },
   },
+  orderedLists: {
+    /** When true, ordered list markers are hidden and replaced with computed numbers (lazy `1.` numbering, etc.). When false, the source text is shown as written. */
+    autoNumber(): boolean {
+      return vscode.workspace
+        .getConfiguration(SECTION)
+        .get<boolean>('orderedLists.autoNumber', true);
+    },
+    /** When auto-numbering is on, tint the displayed marker when it differs from the number in the source. */
+    warnWhenSourceNumberDiffers(): boolean {
+      return vscode.workspace
+        .getConfiguration(SECTION)
+        .get<boolean>('orderedLists.warnWhenSourceNumberDiffers', true);
+    },
+  },
   mentions: {
     /** If set, overrides GitHub context: true = force links on, false = force off. Unset = use git remote auto-detect. */
     linksEnabled(): boolean | undefined {

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -437,13 +437,20 @@ export function ListItemDecorationType(color?: string | ThemeColor) {
 /**
  * Creates a decoration type for ordered list item marker styling.
  *
+ * Hides the original marker (e.g., `1.`, `2)`) and uses per-range renderOptions
+ * to display auto-calculated numbers.
+ *
  * @param {string | ThemeColor | undefined} color - Optional hex or theme color; when undefined uses editor.foreground
  * @returns {vscode.TextEditorDecorationType} A decoration type for ordered list item markers
  */
 export function OrderedListItemDecorationType(color?: string | ThemeColor) {
   const resolvedColor = color ?? new ThemeColor('editor.foreground');
   return window.createTextEditorDecorationType({
-    color: resolvedColor,
+    textDecoration: 'none; display: none;',
+    before: {
+      contentText: '',
+      color: resolvedColor,
+    },
   });
 }
 

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -748,7 +748,7 @@ export class Decorator {
 
     // Types that use per-range renderOptions (DecorationOptions, not plain Range)
     const renderOptionsTypes = new Set<DecorationType>([
-      'emoji', 'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableCell',
+      'emoji', 'orderedListItem', 'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableCell',
     ]);
 
     // Apply all decorations by iterating through the type map

--- a/src/decorator/__tests__/visibility-model.test.ts
+++ b/src/decorator/__tests__/visibility-model.test.ts
@@ -203,6 +203,118 @@ describe('selection overlay for codeBlock/frontmatter', () => {
   });
 });
 
+describe('ordered list auto-numbering decoration', () => {
+  it('renders replacement text when cursor is not on the list line', () => {
+    const text = '1. First\n1. Second\n1. Third\nother line';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 3, type: 'orderedListItem', replacement: '1. ' } as any,
+      { startPos: 9, endPos: 12, type: 'orderedListItem', replacement: '2. ' } as any,
+      { startPos: 19, endPos: 22, type: 'orderedListItem', replacement: '3. ' } as any,
+    ];
+    const editor = makeEditor(text, 3, 0); // cursor on "other line"
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const items = result.get('orderedListItem') as any[];
+    expect(items).toBeDefined();
+    expect(items).toHaveLength(3);
+    expect(items[0].renderOptions?.before?.contentText).toBe('1. ');
+    expect(items[1].renderOptions?.before?.contentText).toBe('2. ');
+    expect(items[2].renderOptions?.before?.contentText).toBe('3. ');
+  });
+
+  it('skips orderedListItem when cursor overlaps marker range (raw reveal)', () => {
+    const text = '1. First\n1. Second';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 3, type: 'orderedListItem', replacement: '1. ' } as any,
+      { startPos: 9, endPos: 12, type: 'orderedListItem', replacement: '2. ' } as any,
+    ];
+    const editor = makeEditor(text, 0, 1); // cursor inside "1. " marker on line 0
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const items = result.get('orderedListItem') as any[];
+    // Line 0 marker should be skipped (raw reveal), line 1 should render
+    expect(items).toBeDefined();
+    expect(items).toHaveLength(1);
+    expect(items[0].renderOptions?.before?.contentText).toBe('2. ');
+  });
+
+  it('renders parenthesis delimiter in replacement', () => {
+    const text = '1) First\n1) Second\nother';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 3, type: 'orderedListItem', replacement: '1) ' } as any,
+      { startPos: 9, endPos: 12, type: 'orderedListItem', replacement: '2) ' } as any,
+    ];
+    const editor = makeEditor(text, 2, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const items = result.get('orderedListItem') as any[];
+    expect(items).toBeDefined();
+    expect(items).toHaveLength(2);
+    expect(items[0].renderOptions?.before?.contentText).toBe('1) ');
+    expect(items[1].renderOptions?.before?.contentText).toBe('2) ');
+  });
+
+  it('renders custom start number in replacement', () => {
+    const text = '5. Start here\n1. Next\nother';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 3, type: 'orderedListItem', replacement: '5. ' } as any,
+      { startPos: 14, endPos: 17, type: 'orderedListItem', replacement: '6. ' } as any,
+    ];
+    const editor = makeEditor(text, 2, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const items = result.get('orderedListItem') as any[];
+    expect(items).toBeDefined();
+    expect(items[0].renderOptions?.before?.contentText).toBe('5. ');
+    expect(items[1].renderOptions?.before?.contentText).toBe('6. ');
+  });
+
+  it('uses warning foreground color when orderedListMarkerMismatch is set', () => {
+    const text = '1. First\n1. Second\nother';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 3, type: 'orderedListItem', replacement: '1. ' } as any,
+      {
+        startPos: 9,
+        endPos: 12,
+        type: 'orderedListItem',
+        replacement: '2. ',
+        orderedListMarkerMismatch: true,
+      } as any,
+    ];
+    const editor = makeEditor(text, 2, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const items = result.get('orderedListItem') as any[];
+    expect(items[0].renderOptions?.before?.color).toBeUndefined();
+    expect(items[1].renderOptions?.before?.color?.id).toBe('editorWarning.foreground');
+  });
+});
+
 describe('filterDecorationsForEditor — basic cases', () => {
   it('returns empty map when no decorations', () => {
     const editor = makeEditor('hello', 0, 0);

--- a/src/decorator/decoration-categories.ts
+++ b/src/decorator/decoration-categories.ts
@@ -12,6 +12,7 @@ const markerDecorationTypes: ReadonlySet<DecorationType> = new Set<DecorationTyp
   'heading5',
   'heading6',
   'listItem',
+  'orderedListItem',
   'checkboxUnchecked',
   'checkboxChecked',
   'horizontalRule',

--- a/src/decorator/visibility-model.ts
+++ b/src/decorator/visibility-model.ts
@@ -1,4 +1,4 @@
-import { Range, type DecorationOptions, type Position, type TextEditor } from 'vscode';
+import { Range, ThemeColor, type DecorationOptions, type Position, type TextEditor } from 'vscode';
 import type { DecorationRange, DecorationType } from '../parser';
 import { isMarkerDecorationType } from './decoration-categories';
 
@@ -44,6 +44,7 @@ export function filterDecorationsForEditor(
   const selectionOnlyMarkerTypes = new Set<DecorationType>([
     'blockquote',
     'listItem',
+    'orderedListItem',
     'checkboxUnchecked',
     'checkboxChecked',
   ]);
@@ -125,7 +126,22 @@ export function filterDecorationsForEditor(
       }
       // Rendered state: apply marker decorations even on active lines
       const ranges = filtered.get(decoration.type) || [];
-      ranges.push(range);
+      if (decoration.replacement) {
+        const beforeOpts: Record<string, unknown> = {
+          contentText: decoration.replacement,
+        };
+        if (decoration.orderedListMarkerMismatch) {
+          beforeOpts.color = new ThemeColor('editorWarning.foreground');
+        }
+        ranges.push({
+          range,
+          renderOptions: {
+            before: beforeOpts,
+          },
+        });
+      } else {
+        ranges.push(range);
+      }
       filtered.set(decoration.type, ranges);
       continue;
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -10,6 +10,7 @@ import type {
   Image,
   Delete,
   Blockquote,
+  List,
   ListItem,
   ThematicBreak,
   Text,
@@ -45,6 +46,8 @@ export interface DecorationRange {
   slug?: string; // For type 'mention': segment after @ (e.g. username, org/team). Used by link provider to resolve URL. 
   issueNumber?: number; // For type 'issueReference': issue/PR number. Used by link provider to resolve URL.
   ownerRepo?: string; // For type 'issueReference' when repo-scoped (@user/repo#456): the "user/repo" part.
+  /** True when the source marker number differs from the computed replacement (ordered lists only). */
+  orderedListMarkerMismatch?: boolean;
 }
 
 /**
@@ -1861,7 +1864,7 @@ export class MarkdownParser {
    * Processes a list item node.
    *
    * Replaces unordered list markers (-, *, +) with a bullet point (•).
-   * Keeps ordered list markers (1., 2., etc.) as-is (no decoration).
+   * Ordered lists: optionally hides markers and shows computed numbers (see `orderedLists.autoNumber`).
    * Detects and decorates checkboxes ([ ] or [x]) after the marker.
    * Supports both unordered lists (-, *, +) and ordered lists (1., 2., etc.).
    */
@@ -1940,13 +1943,48 @@ export class MarkdownParser {
 
       // Check if followed by '.' or ')'
       if (numEnd < end && (text[numEnd] === "." || text[numEnd] === ")")) {
+        const delimiter = text[numEnd];
         markerEnd = numEnd + 1;
         // Skip optional space after marker
         if (markerEnd < end && text[markerEnd] === " ") {
           markerEnd++;
         }
 
-        // For ordered lists: only add checkbox decoration if present, otherwise apply color styling
+        // Compute auto-numbered replacement from position in parent list
+        const parentList = ancestors[0] as List | undefined;
+        const itemIndex = parentList?.children
+          ? parentList.children.indexOf(node)
+          : -1;
+        const autoNumber = itemIndex >= 0
+          ? (parentList!.start ?? 1) + itemIndex
+          : parseInt(text.slice(markerStart, numEnd), 10);
+        const writtenNumber = parseInt(text.slice(markerStart, numEnd), 10);
+        const replacement = `${autoNumber}${delimiter} `;
+        const autoNumberEnabled = config.orderedLists.autoNumber();
+        const sourceMismatch =
+          autoNumberEnabled &&
+          config.orderedLists.warnWhenSourceNumberDiffers() &&
+          writtenNumber !== autoNumber;
+
+        // Show markers as typed (no computed replacement)
+        if (!autoNumberEnabled) {
+          if (
+            this.tryAddCheckboxDecorations(
+              text,
+              markerStart,
+              markerEnd,
+              end,
+              decorations,
+              true,
+              undefined,
+            )
+          ) {
+            return;
+          }
+          return;
+        }
+
+        // For ordered lists: only add checkbox decoration if present, otherwise auto-number
         // Ordered lists should NOT be decorated with listItem (bullet point)
         if (
           this.tryAddCheckboxDecorations(
@@ -1956,16 +1994,20 @@ export class MarkdownParser {
             end,
             decorations,
             true,
+            replacement,
+            sourceMismatch,
           )
         ) {
           return;
         }
 
-        // Apply color decoration to ordered list markers to ensure they match regular text color
+        // Hide original marker and show auto-calculated number
         decorations.push({
           startPos: markerStart,
           endPos: markerEnd,
           type: "orderedListItem",
+          replacement,
+          orderedListMarkerMismatch: sourceMismatch,
         });
         return;
       }
@@ -1981,6 +2023,8 @@ export class MarkdownParser {
    * @param end - End position of the list item
    * @param decorations - Array to add decorations to
    * @param isOrderedList - Whether this is an ordered list (true) or unordered list (false)
+   * @param orderedReplacement - Auto-numbered replacement text for ordered list markers (omit when auto-number is off)
+   * @param orderedListMarkerMismatch - When true, render ordered marker with a warning tint (source number ≠ computed)
    * @returns true if checkbox was found and decorations were added, false otherwise
    */
   private tryAddCheckboxDecorations(
@@ -1990,6 +2034,8 @@ export class MarkdownParser {
     end: number,
     decorations: DecorationRange[],
     isOrderedList: boolean,
+    orderedReplacement?: string,
+    orderedListMarkerMismatch?: boolean,
   ): boolean {
     // Check for checkbox pattern: [ ] or [x] or [X]
     // GFM requires a space after the closing bracket for task lists
@@ -2016,12 +2062,14 @@ export class MarkdownParser {
     const checkboxEnd = checkboxStart + 3; // [ ], [x], or [X] (space after is not part of checkbox)
     const isChecked = checkChar === "x" || checkChar === "X";
 
-    // For ordered lists with checkboxes, apply color decoration to the numbers
-    if (isOrderedList) {
+    // For ordered lists with checkboxes, hide marker and show auto-numbered replacement
+    if (isOrderedList && orderedReplacement !== undefined) {
       decorations.push({
         startPos: markerStart,
         endPos: markerEnd,
         type: "orderedListItem",
+        replacement: orderedReplacement,
+        orderedListMarkerMismatch: orderedListMarkerMismatch,
       });
     }
     // For unordered lists: no listItem (bullet); single checkbox decoration covers marker + checkbox

--- a/src/parser/__tests__/parser-checkbox.test.ts
+++ b/src/parser/__tests__/parser-checkbox.test.ts
@@ -119,22 +119,24 @@ describe('MarkdownParser - Checkbox/Task List', () => {
       expect(result.some(d => d.type === 'checkboxChecked')).toBe(false);
     });
 
-    it('should not create any decoration for ordered list without checkbox', () => {
+    it('should create orderedListItem decoration for ordered list without checkbox', () => {
       const markdown = '1. Regular ordered item';
       const result = parser.extractDecorations(markdown);
 
-      // Ordered lists should NOT have listItem decoration (they keep their numbers visible)
+      // Ordered lists get orderedListItem decoration with auto-numbered replacement
       expect(result.some(d => d.type === 'listItem')).toBe(false);
+      expect(result.some(d => d.type === 'orderedListItem')).toBe(true);
       expect(result.some(d => d.type === 'checkboxUnchecked')).toBe(false);
       expect(result.some(d => d.type === 'checkboxChecked')).toBe(false);
     });
 
-    it('should not create any decoration for ordered list with parentheses marker', () => {
+    it('should create orderedListItem decoration for ordered list with parentheses marker', () => {
       const markdown = '1) Regular ordered item';
       const result = parser.extractDecorations(markdown);
 
-      // Ordered lists should NOT have listItem decoration (they keep their numbers visible)
+      // Ordered lists get orderedListItem decoration with auto-numbered replacement
       expect(result.some(d => d.type === 'listItem')).toBe(false);
+      expect(result.some(d => d.type === 'orderedListItem')).toBe(true);
       expect(result.some(d => d.type === 'checkboxUnchecked')).toBe(false);
       expect(result.some(d => d.type === 'checkboxChecked')).toBe(false);
     });

--- a/src/parser/__tests__/parser-ordered-list.test.ts
+++ b/src/parser/__tests__/parser-ordered-list.test.ts
@@ -1,0 +1,191 @@
+import { MarkdownParser } from '../../parser';
+import { config } from '../../config';
+
+describe('MarkdownParser - Ordered List Auto-Numbering', () => {
+  let parser: MarkdownParser;
+
+  beforeEach(async () => {
+    parser = await MarkdownParser.create();
+  });
+
+  describe('basic auto-numbering with dot syntax', () => {
+    it('should produce orderedListItem decorations with auto-numbered replacement', () => {
+      const markdown = '1. First\n2. Second\n3. Third';
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(3);
+      expect(ordered[0].replacement).toBe('1. ');
+      expect(ordered[1].replacement).toBe('2. ');
+      expect(ordered[2].replacement).toBe('3. ');
+    });
+
+    it('should auto-number when all markers are 1.', () => {
+      const markdown = '1. First\n1. Second\n1. Third';
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(3);
+      expect(ordered[0].replacement).toBe('1. ');
+      expect(ordered[1].replacement).toBe('2. ');
+      expect(ordered[2].replacement).toBe('3. ');
+    });
+
+    it('should auto-number out-of-order markers based on position', () => {
+      const markdown = '3. First\n1. Second\n2. Third';
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(3);
+      // Remark normalizes: list starts at 3, items are sequential by position
+      expect(ordered[0].replacement).toBe('3. ');
+      expect(ordered[1].replacement).toBe('4. ');
+      expect(ordered[2].replacement).toBe('5. ');
+    });
+  });
+
+  describe('parenthesis syntax', () => {
+    it('should produce auto-numbered replacement with ) delimiter', () => {
+      const markdown = '1) First\n1) Second\n1) Third';
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(3);
+      expect(ordered[0].replacement).toBe('1) ');
+      expect(ordered[1].replacement).toBe('2) ');
+      expect(ordered[2].replacement).toBe('3) ');
+    });
+  });
+
+  describe('marker range', () => {
+    it('should cover the full marker including trailing space', () => {
+      const markdown = '1. Item';
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(1);
+      // '1. ' is 3 characters (digit, dot, space)
+      expect(ordered[0].startPos).toBe(0);
+      expect(ordered[0].endPos).toBe(3);
+    });
+
+    it('should handle multi-digit numbers', () => {
+      // Use all-same markers so remark treats them as one list
+      const lines = Array.from({ length: 12 }, (_, i) => `1. Item ${i + 1}`);
+      const markdown = lines.join('\n');
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(12);
+      expect(ordered[9].replacement).toBe('10. ');
+      expect(ordered[11].replacement).toBe('12. ');
+    });
+  });
+
+  describe('nested ordered lists', () => {
+    it('should auto-number inner list independently from outer list', () => {
+      const markdown = '1. Outer 1\n   1. Inner 1\n   1. Inner 2\n1. Outer 2';
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      // Expect 4 items: 2 outer + 2 inner, each numbered sequentially
+      expect(ordered).toHaveLength(4);
+
+      // Outer items should be numbered 1, 2
+      const outerItems = ordered.filter(d => d.replacement?.startsWith('1.') || d.replacement?.startsWith('2.'));
+      expect(outerItems.some(d => d.replacement === '1. ')).toBe(true);
+      expect(outerItems.some(d => d.replacement === '2. ')).toBe(true);
+    });
+  });
+
+  describe('single item list', () => {
+    it('should produce replacement for a single-item ordered list', () => {
+      const markdown = '1. Only item';
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(1);
+      expect(ordered[0].replacement).toBe('1. ');
+    });
+  });
+
+  describe('ordered list scope', () => {
+    it('should create a listItem scope for ordered list items', () => {
+      const markdown = '1. Item one\n2. Item two';
+      const { scopes } = parser.extractDecorationsWithScopes(markdown);
+
+      const listScopes = scopes.filter(s => s.kind === 'listItem');
+      expect(listScopes.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('ordered list with checkboxes', () => {
+    it('should produce orderedListItem decoration with replacement for checkbox items', () => {
+      const markdown = '1. [ ] Task 1\n2. [x] Task 2';
+      const result = parser.extractDecorations(markdown);
+
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(2);
+      expect(ordered[0].replacement).toBe('1. ');
+      expect(ordered[1].replacement).toBe('2. ');
+
+      // Checkboxes should also be present
+      expect(result.some(d => d.type === 'checkboxUnchecked')).toBe(true);
+      expect(result.some(d => d.type === 'checkboxChecked')).toBe(true);
+    });
+  });
+
+  describe('source vs computed number (mismatch hint)', () => {
+    it('should set orderedListMarkerMismatch for lazy 1. lists when position advances', () => {
+      const markdown = '1. First\n1. Second\n1. Third';
+      const result = parser.extractDecorations(markdown);
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered).toHaveLength(3);
+      expect(ordered[0].orderedListMarkerMismatch).toBeFalsy();
+      expect(ordered[1].orderedListMarkerMismatch).toBe(true);
+      expect(ordered[2].orderedListMarkerMismatch).toBe(true);
+    });
+
+    it('should not set mismatch when source markers match the computed sequence', () => {
+      const markdown = '1. First\n2. Second\n3. Third';
+      const result = parser.extractDecorations(markdown);
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered.every(d => !d.orderedListMarkerMismatch)).toBe(true);
+    });
+  });
+
+  describe('when orderedLists.autoNumber is false', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should not emit orderedListItem decorations', () => {
+      jest.spyOn(config.orderedLists, 'autoNumber').mockReturnValue(false);
+      const markdown = '1. First\n2. Second';
+      const result = parser.extractDecorations(markdown);
+      expect(result.filter(d => d.type === 'orderedListItem')).toHaveLength(0);
+    });
+
+    it('should still decorate checkboxes without hiding the ordered marker', () => {
+      jest.spyOn(config.orderedLists, 'autoNumber').mockReturnValue(false);
+      const markdown = '1. [ ] Task';
+      const result = parser.extractDecorations(markdown);
+      expect(result.filter(d => d.type === 'orderedListItem')).toHaveLength(0);
+      expect(result.some(d => d.type === 'checkboxUnchecked')).toBe(true);
+    });
+  });
+
+  describe('when orderedLists.warnWhenSourceNumberDiffers is false', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should not set orderedListMarkerMismatch even for lazy lists', () => {
+      jest.spyOn(config.orderedLists, 'warnWhenSourceNumberDiffers').mockReturnValue(false);
+      const markdown = '1. First\n1. Second';
+      const result = parser.extractDecorations(markdown);
+      const ordered = result.filter(d => d.type === 'orderedListItem');
+      expect(ordered.every(d => !d.orderedListMarkerMismatch)).toBe(true);
+    });
+  });
+});

--- a/src/test/e2e/fixtures/sample.md
+++ b/src/test/e2e/fixtures/sample.md
@@ -12,3 +12,30 @@
 ---
 
 [link text](https://example.com)
+
+## Ordered Lists
+
+1. First item
+1. Second item
+1. Third item
+
+1) Parentheses A
+1) Parentheses B
+1) Parentheses C
+
+5. Custom start
+1. Next
+1. And next
+
+1. [ ] Ordered task unchecked
+2. [x] Ordered task checked
+
+### Nested
+
+1. Outer one
+   1. Inner one
+   1. Inner two
+1. Outer two
+   1. Inner one
+   1. Inner two
+   1. Inner three

--- a/src/test/e2e/suite/extension.test.ts
+++ b/src/test/e2e/suite/extension.test.ts
@@ -278,6 +278,19 @@ suite('Extension E2E', () => {
     assert.strictEqual(doc.languageId, 'markdown');
   });
 
+  // Issue #31: ordered list auto-numbering
+  // Ordered list markers should be hidden and replaced with auto-calculated numbers.
+  test('#31 — ordered list auto-numbering decorates without error', async () => {
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: '1. First item\n1. Second item\n1. Third item\n\nNested:\n1. Outer\n   1. Inner A\n   1. Inner B\n1. Outer again',
+    });
+    await vscode.window.showTextDocument(doc);
+    await delay(500);
+    assert.strictEqual(doc.languageId, 'markdown');
+    // Extension must not throw while decorating ordered lists with auto-numbering.
+  });
+
   // Edge case: an empty markdown document should not throw.
   test('empty markdown document decorates without error', async () => {
     const doc = await vscode.workspace.openTextDocument({


### PR DESCRIPTION
Closes #31

## Summary

- Ordered list markers (`1.`, `2.`, `1)`, etc.) can be hidden via `display: none` and replaced with **auto-calculated** sequential numbers from list position (`List.start + item index`). This is **display-only**: the file on disk is never modified.
- Supports lazy numbering (all `1.`), custom start numbers, both `.` and `)` delimiters, nested lists, and ordered list items with checkboxes.
- Cursor on a list item reveals the raw markdown marker (consistent with other marker types).
- **Optional behavior:** `markdownInlineEditor.orderedLists.autoNumber` (default `true`) turns this replacement on or off. When off, markers are shown **exactly as written** (stronger “source fidelity” for users who do not want computed numbers in the view).
- **Visual cue:** when auto-numbering is on, `markdownInlineEditor.orderedLists.warnWhenSourceNumberDiffers` (default `true`) tints the **rendered** marker with `editorWarning.foreground` when the number in the source does not match the computed number (for example lazy `1.` lists where the view shows `2.`, `3.`, …).

<img width="357" height="370" alt="grafik" src="https://github.com/user-attachments/assets/518bdce1-d77b-4c27-b23d-9cde683f7e47" />
