### PR TITLE
feat(headings): optional outline indent for nested headings (#82)

### DIFF
--- a/docs/uat/heading-nest.test.md
+++ b/docs/uat/heading-nest.test.md
@@ -1,0 +1,115 @@
+---
+title: UAT — Heading outline indent (issue #82)
+---
+
+# Heading nest — manual UAT
+
+**Prerequisite:** In Settings, enable **Markdown Inline Editor › Headings › Nest: Enabled** (`markdownInlineEditor.headings.nest.enabled`).
+
+Optional toggles to exercise while testing:
+
+| Setting | Purpose |
+| --- | --- |
+| `headings.nest.indentPerLevelCh` | Width per level (default `1.25`) |
+| `headings.nest.nestContent` | Indent body under each heading until the next peer-or-higher heading (default on) |
+| `headings.nest.showIndentGuides` | Subtle **vertical** line at the gutter’s left edge (default **off**; avoids old full-border rendering that looked like horizontal dashes) |
+| `headings.nest.maxLevel` | Cap depth (e.g. `4` = no extra indent past `####`) |
+
+---
+
+## Checklist (global)
+
+With **nest enabled**, away from any decorated line:
+
+- [ ] H1 lines have **no** extra left indent (baseline).
+- [ ] H2+ heading lines step in per level; deeper headings indent more than shallower ones.
+- [ ] With **nest content** on, paragraphs and lists under a heading align with that heading’s indent until the next same-or-higher-level heading.
+- [ ] **Fenced code blocks** (and their lines) are **not** outline-indented.
+- [ ] **Frontmatter** lines are not outline-indented.
+- [ ] With **show indent guides** on, a **vertical** cue appears at the left of the gutter (not horizontal “underscore” segments across the indent).
+
+With **nest enabled**, **cursor on a heading line** (active line):
+
+- [ ] Heading **syntax** behaves as today (raw/ghost per extension rules).
+- [ ] **Outline indent** for that line is **off** (no fake indent while editing the line).
+
+**Disabled** (`headings.nest.enabled` = false):
+
+- [ ] No outline indent or guide; document looks as before the feature.
+
+UAT-CHECK()
+
+---
+
+## Sample outline (H1 → H4 + body)
+
+Use this block with nest enabled. Visually confirm nesting increases down the outline and body text follows the owning heading.
+
+# Chapter title
+
+Introduction paragraph under H1. Should match H1 indent (none beyond normal margin).
+
+## Section A
+
+Body under H2. Should align with **Section A** indent, not stay flush like the H1 intro if nest content is on.
+
+### Subsection A.1
+
+Body under H3. Deeper indent than Section A body.
+
+#### Detail A.1.i
+
+Short body under H4.
+
+Back to ### level: this line is still under **Subsection A.1** until the next `##` or `#`.
+
+## Section B
+
+This paragraph resets to **H2** section indent (peer `##` closed the H3 subtree).
+
+UAT-CHECK()
+
+---
+
+## Nested headings without extra “double” indent on the child heading line
+
+The `###` line below must be indented **only** as an H3 heading, not stacked as H2-section-body **and** H3.
+
+## Parent
+
+Bridge paragraph.
+
+### Child heading
+
+This line is the H3 title only (verify single step from document left, not “double” indent).
+
+UAT-CHECK()
+
+---
+
+## Code block must not get outline indent
+
+```text
+This fenced block should not receive heading-nest gutter indent.
+Even though it sits under a heading.
+```
+
+UAT-CHECK()
+
+---Í
+
+## maxLevel quick check (optional)
+
+Set `headings.nest.maxLevel` to **2**, reload / reopen file:
+
+# Only H1
+
+## H2
+
+### H3
+
+#### H4
+
+Expect: **H3** and **H4** lines use the **same** indent as **H2** (capped at level 2). Reset `maxLevel` to `6` after.
+
+UAT-CHECK()

--- a/package.json
+++ b/package.json
@@ -111,6 +111,40 @@
           "description": "Opacity for code block language identifiers",
           "markdownDescription": "Opacity of code block language identifiers (0.0-1.0)."
         },
+        "markdownInlineEditor.headings.nest.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Visually indent headings (and optional body) by heading level",
+          "markdownDescription": "When enabled, headings nest like an outline: each level is indented slightly. Optional vertical line uses the theme's indent-guide color. Does not change the file contents."
+        },
+        "markdownInlineEditor.headings.nest.indentPerLevelCh": {
+          "type": "number",
+          "default": 1.25,
+          "minimum": 0,
+          "maximum": 6,
+          "description": "Indentation per heading level, in ch units",
+          "markdownDescription": "Horizontal indent per heading level, in `ch` units (one character width). Use small values (for example 1–2) so nesting stays subtle."
+        },
+        "markdownInlineEditor.headings.nest.nestContent": {
+          "type": "boolean",
+          "default": true,
+          "description": "Indent body text under each heading until the next same-or-higher-level heading",
+          "markdownDescription": "When enabled, lines between a heading and the next heading of equal or higher level are indented to match that heading. Code blocks and frontmatter are excluded."
+        },
+        "markdownInlineEditor.headings.nest.showIndentGuides": {
+          "type": "boolean",
+          "default": false,
+          "description": "Draw a subtle vertical line at the indent (theme indent-guide color)",
+          "markdownDescription": "Draw a subtle vertical line at the left of the gutter (`box-shadow` + indent-guide CSS variable). Off by default."
+        },
+        "markdownInlineEditor.headings.nest.maxLevel": {
+          "type": "integer",
+          "default": 6,
+          "minimum": 1,
+          "maximum": 6,
+          "description": "Maximum heading depth that increases indent",
+          "markdownDescription": "Headings deeper than this use the same indent as this level (for example set to 4 to cap nesting at `####`)."
+        },
         "markdownInlineEditor.links.singleClickOpen": {
           "type": "boolean",
           "default": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,45 @@ export const config = {
         .get<boolean>('math.enabled', true);
     },
   },
+  headings: {
+    nest: {
+      enabled(): boolean {
+        return vscode.workspace
+          .getConfiguration(SECTION)
+          .get<boolean>('headings.nest.enabled', false);
+      },
+      /** Indent width per heading level step, in `ch` units (matches editor character width). */
+      indentPerLevelCh(): number {
+        const v = vscode.workspace
+          .getConfiguration(SECTION)
+          .get<number>('headings.nest.indentPerLevelCh', 1.25);
+        if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
+          return 1.25;
+        }
+        return Math.min(6, Math.max(0, v));
+      },
+      nestContent(): boolean {
+        return vscode.workspace
+          .getConfiguration(SECTION)
+          .get<boolean>('headings.nest.nestContent', true);
+      },
+      showIndentGuides(): boolean {
+        return vscode.workspace
+          .getConfiguration(SECTION)
+          .get<boolean>('headings.nest.showIndentGuides', false);
+      },
+      /** Headings deeper than this use the same indent as this level (1–6). */
+      maxLevel(): number {
+        const v = vscode.workspace
+          .getConfiguration(SECTION)
+          .get<number>('headings.nest.maxLevel', 6);
+        if (typeof v !== 'number' || !Number.isFinite(v)) {
+          return 6;
+        }
+        return Math.min(6, Math.max(1, Math.round(v)));
+      },
+    },
+  },
   mentions: {
     /** If set, overrides GitHub context: true = force links on, false = force off. Unset = use git remote auto-detect. */
     linksEnabled(): boolean | undefined {

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -264,6 +264,14 @@ export function EmojiDecorationType() {
  *
  * @returns {vscode.TextEditorDecorationType} A decoration type for headings
  */
+/**
+ * Base type for per-line heading outline indent. Actual width and guide line come from
+ * per-range `renderOptions` (see visibility model).
+ */
+export function HeadingNestDecorationType() {
+  return window.createTextEditorDecorationType({});
+}
+
 export function HeadingDecorationType() {
   return window.createTextEditorDecorationType({
     fontWeight: 'bold',

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -748,7 +748,7 @@ export class Decorator {
 
     // Types that use per-range renderOptions (DecorationOptions, not plain Range)
     const renderOptionsTypes = new Set<DecorationType>([
-      'emoji', 'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableCell',
+      'emoji', 'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableCell', 'headingNest',
     ]);
 
     // Apply all decorations by iterating through the type map

--- a/src/decorator/__tests__/visibility-model.test.ts
+++ b/src/decorator/__tests__/visibility-model.test.ts
@@ -7,6 +7,7 @@ jest.mock('../../parser', () => ({
 import { filterDecorationsForEditor } from '../visibility-model';
 import type { ScopeEntry } from '../visibility-model';
 import type { DecorationRange } from '../../parser';
+import { config } from '../../config';
 import { TextDocument, TextEditor, Selection, Position, Uri, Range } from '../../test/__mocks__/vscode';
 
 function makeEditor(text: string, cursorLine: number, cursorChar: number) {
@@ -150,6 +151,72 @@ describe('table decoration rendering', () => {
     expect(cells).toBeDefined();
     expect(cells[0].renderOptions?.before?.contentText).toBe(' bold ');
     expect(cells[0].renderOptions?.before?.fontWeight).toBe('bold');
+  });
+});
+
+describe('headingNest', () => {
+  beforeEach(() => {
+    jest.spyOn(config.headings.nest, 'indentPerLevelCh').mockReturnValue(1);
+    jest.spyOn(config.headings.nest, 'showIndentGuides').mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders before width from nestSteps when cursor is not on that line', () => {
+    const text = '## H\n\nx';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 4, type: 'headingNest', nestSteps: 2 } as any,
+    ];
+    const editor = makeEditor(text, 2, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const nests = result.get('headingNest') as any[];
+    expect(nests?.length).toBe(1);
+    expect(nests[0].renderOptions?.before?.width).toBe('2ch');
+  });
+
+  it('omits headingNest on the active line', () => {
+    const text = '## H\n';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 4, type: 'headingNest', nestSteps: 2 } as any,
+    ];
+    const editor = makeEditor(text, 0, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    expect(result.has('headingNest')).toBe(false);
+  });
+
+  it('uses inset box-shadow for indent guides instead of a full border', () => {
+    jest.spyOn(config.headings.nest, 'showIndentGuides').mockReturnValue(true);
+    const text = '## H\n\nx';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 4, type: 'headingNest', nestSteps: 1 } as any,
+    ];
+    const editor = makeEditor(text, 2, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const before = (result.get('headingNest') as any[])[0].renderOptions.before;
+    expect(before.textDecoration).toContain('box-shadow');
+    expect(before.textDecoration).toContain('inset');
+    expect(before.border).toBeUndefined();
+    expect(before.borderColor).toBeUndefined();
   });
 });
 

--- a/src/decorator/decoration-type-registry.ts
+++ b/src/decorator/decoration-type-registry.ts
@@ -12,6 +12,7 @@ import {
   CodeBlockLanguageDecorationType,
   SelectionOverlayDecorationType,
   HeadingDecorationType,
+  HeadingNestDecorationType,
   Heading1DecorationType,
   Heading2DecorationType,
   Heading3DecorationType,
@@ -72,6 +73,7 @@ export class DecorationTypeRegistry {
   private codeBlockLanguageDecorationType!: TextEditorDecorationType;
   private selectionOverlayDecorationType!: TextEditorDecorationType;
   private headingDecorationType!: TextEditorDecorationType;
+  private headingNestDecorationType!: TextEditorDecorationType;
   private heading1DecorationType!: TextEditorDecorationType;
   private heading2DecorationType!: TextEditorDecorationType;
   private heading3DecorationType!: TextEditorDecorationType;
@@ -111,6 +113,7 @@ export class DecorationTypeRegistry {
     this.codeBlockLanguageDecorationType = CodeBlockLanguageDecorationType(this.options.getCodeBlockLanguageOpacity());
     this.selectionOverlayDecorationType = SelectionOverlayDecorationType();
     this.headingDecorationType = HeadingDecorationType();
+    this.headingNestDecorationType = HeadingNestDecorationType();
     this.heading1DecorationType = Heading1DecorationType(this.options.getHeading1Color?.());
     this.heading2DecorationType = Heading2DecorationType(this.options.getHeading2Color?.());
     this.heading3DecorationType = Heading3DecorationType(this.options.getHeading3Color?.());
@@ -146,6 +149,7 @@ export class DecorationTypeRegistry {
       ['codeBlock', this.codeBlockDecorationType],
       ['codeBlockLanguage', this.codeBlockLanguageDecorationType],
       ['heading', this.headingDecorationType],
+      ['headingNest', this.headingNestDecorationType],
       ['heading1', this.heading1DecorationType],
       ['heading2', this.heading2DecorationType],
       ['heading3', this.heading3DecorationType],

--- a/src/decorator/visibility-model.ts
+++ b/src/decorator/visibility-model.ts
@@ -1,5 +1,6 @@
 import { Range, type DecorationOptions, type Position, type TextEditor } from 'vscode';
 import type { DecorationRange, DecorationType } from '../parser';
+import { config } from '../config';
 import { isMarkerDecorationType } from './decoration-categories';
 
 export type ScopeEntry = {
@@ -132,6 +133,39 @@ export function filterDecorationsForEditor(
 
     if (headingTypes.has(decoration.type) && isActiveLine) {
       // Show raw heading text (no heading styling) on active lines
+      continue;
+    }
+
+    if (decoration.type === 'headingNest') {
+      const steps = decoration.nestSteps ?? 0;
+      if (steps <= 0) {
+        continue;
+      }
+      if (isActiveLine) {
+        continue;
+      }
+      const indentCh = config.headings.nest.indentPerLevelCh();
+      const widthCh = steps * indentCh;
+      // Never use `border: 1px solid` on a wide `before` attachment: VS Code draws
+      // top and bottom edges across the full width, which looks like horizontal "underscore" lines.
+      const before: {
+        contentText: string;
+        width: string;
+        textDecoration?: string;
+      } = {
+        contentText: '',
+        width: `${widthCh}ch`,
+      };
+      if (config.headings.nest.showIndentGuides()) {
+        before.textDecoration =
+          'none; box-shadow: inset 1px 0 0 0 var(--vscode-editorIndentGuide-background);';
+      }
+      const ranges = filtered.get(decoration.type) || [];
+      ranges.push({
+        range,
+        renderOptions: { before },
+      });
+      filtered.set(decoration.type, ranges);
       continue;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -249,6 +249,11 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
       decorator.recreateColorDependentTypes();
     }
 
+    if (event.affectsConfiguration('markdownInlineEditor.headings.nest')) {
+      parseCache.clear();
+      decorator.updateDecorationsForSelection();
+    }
+
     if (event.affectsConfiguration('editor.fontSize') || event.affectsConfiguration('editor.lineHeight')) {
       decorator.clearMathDecorationCache();
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -45,6 +45,8 @@ export interface DecorationRange {
   slug?: string; // For type 'mention': segment after @ (e.g. username, org/team). Used by link provider to resolve URL. 
   issueNumber?: number; // For type 'issueReference': issue/PR number. Used by link provider to resolve URL.
   ownerRepo?: string; // For type 'issueReference' when repo-scoped (@user/repo#456): the "user/repo" part.
+  /** For `headingNest`: indent depth in steps (0 = none). */
+  nestSteps?: number;
 }
 
 /**
@@ -133,7 +135,8 @@ export type DecorationType =
   | "tableSeparatorDash"
   | "tableCell"
   | "mention"
-  | "issueReference";
+  | "issueReference"
+  | "headingNest";
 
 /**
  * Type for the unified processor used to parse markdown text to a Root AST node.
@@ -242,6 +245,8 @@ export class MarkdownParser {
 
       // Process AST nodes and extract decorations + scopes
       this.processAST(ast, normalizedText, decorations, scopes, mermaidBlocks);
+
+      this.addHeadingNestDecorations(normalizedText, ast, decorations, scopes);
 
       // Handle edge cases: empty image alt text that remark doesn't parse as Image node
       this.handleEmptyImageAlt(normalizedText, decorations);
@@ -877,6 +882,147 @@ export class MarkdownParser {
     }
 
     this.addScope(scopes, start, contentEnd, "heading");
+  }
+
+  /**
+   * Offsets for a 0-based line index (end is exclusive, excludes newline).
+   */
+  private lineOffsets(text: string, lineIndex0: number): { start: number; end: number } {
+    let start = 0;
+    for (let i = 0; i < lineIndex0; i++) {
+      const n = text.indexOf("\n", start);
+      if (n === -1) {
+        return { start: text.length, end: text.length };
+      }
+      start = n + 1;
+    }
+    const n = text.indexOf("\n", start);
+    const end = n === -1 ? text.length : n;
+    return { start, end };
+  }
+
+  private lineIntersectsExcludedNestContext(
+    lineStart: number,
+    lineEnd: number,
+    scopes: ScopeRange[],
+  ): boolean {
+    for (const s of scopes) {
+      if (s.kind !== "codeBlock" && s.kind !== "frontmatter") {
+        continue;
+      }
+      if (lineStart < s.endPos && lineEnd > s.startPos) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Adds visual indent (and optional guide) for headings and, when enabled,
+   * for body lines under each heading until the next heading of equal or higher level.
+   */
+  private addHeadingNestDecorations(
+    text: string,
+    ast: Root,
+    decorations: DecorationRange[],
+    scopes: ScopeRange[],
+  ): void {
+    if (!config.headings.nest.enabled()) {
+      return;
+    }
+
+    const maxLevel = config.headings.nest.maxLevel();
+    const nestContent = config.headings.nest.nestContent();
+    const maxLineIndex = Math.max(0, text.split("\n").length - 1);
+
+    const headings: Array<{ line: number; level: number }> = [];
+    const ancestorMap = new Map<Node, Node[]>();
+
+    this.visit(
+      ast,
+      (node: Node, index: number | undefined, parent: Node | undefined) => {
+        const currentAncestors: Node[] = [];
+        if (parent) {
+          currentAncestors.push(parent);
+          const parentAncestors = ancestorMap.get(parent);
+          if (parentAncestors) {
+            currentAncestors.push(...parentAncestors);
+          }
+        }
+        if (currentAncestors.length > 0) {
+          ancestorMap.set(node, currentAncestors);
+        }
+
+        if (node.type !== "heading") {
+          return;
+        }
+        const h = node as Heading;
+        if (!this.hasValidPosition(h) || this.isInCodeBlock(currentAncestors)) {
+          return;
+        }
+        const line = h.position!.start.line - 1;
+        const depth = h.depth ?? 1;
+        const level = Math.min(Math.max(depth, 1), 6);
+        headings.push({ line, level });
+      },
+    );
+
+    const pushNestLine = (line: number, nestSteps: number): void => {
+      if (nestSteps <= 0) {
+        return;
+      }
+      const { start, end } = this.lineOffsets(text, line);
+      if (start >= end) {
+        return;
+      }
+      if (this.lineIntersectsExcludedNestContext(start, end, scopes)) {
+        return;
+      }
+      decorations.push({
+        startPos: start,
+        endPos: end,
+        type: "headingNest",
+        nestSteps,
+      });
+    };
+
+    const cappedSteps = (level: number): number => {
+      const capped = Math.min(level, maxLevel);
+      return Math.max(0, capped - 1);
+    };
+
+    const headingLineSet = new Set(headings.map((h) => h.line));
+
+    for (let i = 0; i < headings.length; i++) {
+      const { line: hLine, level } = headings[i];
+      const steps = cappedSteps(level);
+      pushNestLine(hLine, steps);
+
+      if (!nestContent) {
+        continue;
+      }
+
+      let sectionEndLine: number;
+      if (i + 1 >= headings.length) {
+        sectionEndLine = maxLineIndex;
+      } else {
+        let endBefore = maxLineIndex;
+        for (let j = i + 1; j < headings.length; j++) {
+          if (headings[j].level <= level) {
+            endBefore = headings[j].line - 1;
+            break;
+          }
+        }
+        sectionEndLine = endBefore;
+      }
+
+      for (let line = hLine + 1; line <= sectionEndLine; line++) {
+        if (headingLineSet.has(line)) {
+          continue;
+        }
+        pushNestLine(line, steps);
+      }
+    }
   }
 
   /**

--- a/src/parser/__tests__/heading-nest.test.ts
+++ b/src/parser/__tests__/heading-nest.test.ts
@@ -1,0 +1,62 @@
+import { config } from '../../config';
+import { MarkdownParser } from '../../parser';
+
+describe('heading nest decorations', () => {
+  let parser: MarkdownParser;
+
+  beforeEach(async () => {
+    parser = await MarkdownParser.create();
+    jest.spyOn(config.headings.nest, 'enabled').mockReturnValue(true);
+    jest.spyOn(config.headings.nest, 'nestContent').mockReturnValue(true);
+    jest.spyOn(config.headings.nest, 'maxLevel').mockReturnValue(6);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('adds headingNest with nestSteps for heading lines by depth', () => {
+    const text = '# One\n\n## Two\n\n### Three\n';
+    const decs = parser.extractDecorations(text);
+    const nests = decs.filter((d) => d.type === 'headingNest');
+    expect(nests.some((d) => d.nestSteps === 0)).toBe(false);
+    expect(nests.filter((d) => d.nestSteps === 1)).toHaveLength(1);
+    expect(nests.filter((d) => d.nestSteps === 2)).toHaveLength(1);
+  });
+
+  it('indents body lines when nestContent is true', () => {
+    const text = '## H\n\nbody line\n\n# H1\n';
+    const decs = parser.extractDecorations(text);
+    const nests = decs.filter((d) => d.type === 'headingNest');
+    const bodyNest = nests.find((d) => {
+      const snippet = text.slice(d.startPos, d.endPos);
+      return snippet === 'body line';
+    });
+    expect(bodyNest).toBeDefined();
+    expect(bodyNest!.nestSteps).toBe(1);
+  });
+
+  it('does not add headingNest when disabled', () => {
+    jest.spyOn(config.headings.nest, 'enabled').mockReturnValue(false);
+    const text = '## Two\npara\n';
+    const decs = parser.extractDecorations(text);
+    expect(decs.some((d) => d.type === 'headingNest')).toBe(false);
+  });
+
+  it('does not nest body when nestContent is false', () => {
+    jest.spyOn(config.headings.nest, 'nestContent').mockReturnValue(false);
+    const text = '## H\n\nbody\n';
+    const decs = parser.extractDecorations(text);
+    const nests = decs.filter((d) => d.type === 'headingNest');
+    expect(nests.length).toBe(1);
+    expect(text.slice(nests[0].startPos, nests[0].endPos).includes('##')).toBe(true);
+  });
+
+  it('skips fenced code block lines for nest', () => {
+    const text = '## H\n\n```js\nx\n```\n\np\n';
+    const decs = parser.extractDecorations(text);
+    const nests = decs.filter((d) => d.type === 'headingNest');
+    const codeLine = nests.find((d) => text.slice(d.startPos, d.endPos) === 'x');
+    expect(codeLine).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Implements [issue #82](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/82): optional visual nesting for headings (and optional body under each section until the next peer-or-higher heading).

## Changes
- New settings under `markdownInlineEditor.headings.nest.*` (off by default).
- Parser emits `headingNest` ranges; decorator applies per-line `before` width from live config.
- Skips fenced code blocks and frontmatter; skips nest on the active line (same idea as heading raw line).
- Guide line uses inset `box-shadow` + `--vscode-editorIndentGuide-background` instead of a full `border` (avoids horizontal gutter lines).
- Parse cache cleared when nest settings change; unit tests + UAT doc under `docs/uat/heading-nest.test.md`.

<img width="1010" height="514" alt="image" src="https://github.com/user-attachments/assets/27b234e5-5286-4a50-8d4b-256e8b2bdfce" />