### PR TITLE
feat(tables): Better markdown rendered styling in tables

### DIFF
--- a/docs/table-test-suite.md
+++ b/docs/table-test-suite.md
@@ -1,0 +1,16 @@
+# Table rendering smoke checks
+
+Automated coverage lives in `src/parser/__tests__/parser-table.test.ts` and
+`src/decorator/__tests__/visibility-model.test.ts` (alignment, native vs synthetic cells,
+whole-table raw reveal, wide characters, and edge cases).
+
+For manual checks in the Extension Development Host: open any Markdown file, insert a small
+GFM table (blank line before the table, separator row with at least three hyphens per column),
+then move the caret into and out of the table. The whole table should switch to raw markdown
+while the caret is on any row of that table.
+
+Example:
+
+| A | B |
+|---|---|
+| 1 | 2 |

--- a/docs/table-test-suite.md
+++ b/docs/table-test-suite.md
@@ -1,16 +1,305 @@
-# Table rendering smoke checks
+# Table rendering manual test suite
 
-Automated coverage lives in `src/parser/__tests__/parser-table.test.ts` and
-`src/decorator/__tests__/visibility-model.test.ts` (alignment, native vs synthetic cells,
-whole-table raw reveal, wide characters, and edge cases).
+## Basic grid
 
-For manual checks in the Extension Development Host: open any Markdown file, insert a small
-GFM table (blank line before the table, separator row with at least three hyphens per column),
-then move the caret into and out of the table. The whole table should switch to raw markdown
-while the caret is on any row of that table.
+| Name | Age |
+| ---- | --- |
+| Jo   | 5   |
 
-Example:
+| aa  | bb  | cc  |
+| --- | --- | --- |
+| 11  | 22  | 33  |
+| 44  | 55  | 66  |
 
-| A | B |
-|---|---|
-| 1 | 2 |
+## Four and five columns
+
+| A   | B   | C   | D   |
+| --- | --- | --- | --- |
+| r1  | r1  | r1  | r1  |
+| r2  | r2  | r2  | r2  |
+
+| v   | w   | x   | y   | z   |
+| --- | --- | --- | --- | --- |
+| 1   | 2   | 3   | 4   | 5   |
+| a   | b   | c   | d   | e   |
+
+## Header vs data width
+
+| Short | MuchLongerHeader |
+| ----- | ---------------- |
+| x     | y                |
+
+| VeryWideHeaderText | B   |
+| ------------------ | --- |
+| 1                  | 2   |
+
+## Column alignment
+
+| Left | Center | Right |
+| :--- | :----: | ----: |
+| a    |   b    |     c |
+
+| Foo | Bar |
+| --- | --- |
+| x   | y   |
+
+| L        |  C  |         R |
+| :------- | :-: | --------: |
+| left-pad | mid | right-pad |
+| xx       | yy  |        zz |
+
+## Default alignment (no colons)
+
+| One   | Two  | Three |
+| ----- | ---- | ----- |
+| alpha | beta | gamma |
+
+## Empty and minimal cells
+
+| A   | B   |
+| --- | --- |
+|     | B   |
+
+| Col | Val |
+| --- | --- |
+| B   | B   |
+
+| X   | Y   |
+| --- | --- |
+|     |     |
+
+## Compact syntax (still valid GFM)
+
+| A   | B   |
+| --- | --- |
+| 1   | 2   |
+
+## CJK and emoji width
+
+| Name | CJK  |
+| ---- | ---- |
+| AB   | 你好 |
+
+| Col      | Val      |
+| -------- | -------- |
+| Hiragana | ひらがな |
+
+| Col    | Val  |
+| ------ | ---- |
+| Hangul | 안녕 |
+
+| Col   | Val |
+| ----- | --- |
+| Emoji | 😀  |
+
+| Col    | Val |
+| ------ | --- |
+| Family | 👨‍👩‍👧  |
+
+| Col  | Val |
+| ---- | --- |
+| Flag | 🇯🇵  |
+
+| Name | CJK  | Emoji |
+| ---- | ---- | ----- |
+| AB   | 你好 | 😀    |
+| CD   | 世界 | 🚀    |
+
+## Whole-cell styling (synthetic cells)
+
+| Col      | Note   |
+| -------- | ------ |
+| **bold** | strong |
+
+| Col      | Note              |
+| -------- | ----------------- |
+| **bold** | strong underscore |
+
+| Col      | Note     |
+| -------- | -------- |
+| _italic_ | emphasis |
+
+| Col      | Note                |
+| -------- | ------------------- |
+| _italic_ | emphasis underscore |
+
+| Col          | Note             |
+| ------------ | ---------------- |
+| **_triple_** | bold-italic star |
+
+| Col     | Note                   |
+| ------- | ---------------------- |
+| **_x_** | bold-italic underscore |
+
+| Col        | Note          |
+| ---------- | ------------- |
+| ~~strike~~ | strikethrough |
+
+| Col    | Note            |
+| ------ | --------------- |
+| `code` | whole-cell code |
+
+## Rich cells (native padding)
+
+| Col                          | Note |
+| ---------------------------- | ---- |
+| [label](https://example.com) | link |
+
+| Col                                  | Note                       |
+| ------------------------------------ | -------------------------- |
+| [example](https://example.org/other) | link text differs from URL |
+
+| Col                             | Note  |
+| ------------------------------- | ----- |
+| ![t](https://example.com/x.png) | image |
+
+| Col | Note |
+| --- | ---- |
+| `x` | code |
+
+| Col   | Note      |
+| ----- | --------- |
+| plain | synthetic |
+
+## Mixed inline in one cell
+
+| Col                | Note         |
+| ------------------ | ------------ |
+| **bold** and plain | mixed strong |
+
+| Col     | Note       |
+| ------- | ---------- |
+| a _i_ z | mixed star |
+
+| Col     | Note             |
+| ------- | ---------------- |
+| a _i_ z | mixed underscore |
+
+| Col               | Note            |
+| ----------------- | --------------- |
+| start **mid** end | strong mid-word |
+
+## Literals that must not break
+
+| Col        | Note        |
+| ---------- | ----------- |
+| snake_case | underscores |
+
+| Col      | Note     |
+| -------- | -------- |
+| 100\*200 | asterisk |
+
+| Col        | Note |
+| ---------- | ---- |
+| not_a_link | text |
+
+## Dollar math heuristic
+
+| Col | Note              |
+| --- | ----------------- |
+| $x$ | inline math token |
+
+| Col       | Note                      |
+| --------- | ------------------------- |
+| $$block$$ | double-dollar on one line |
+
+## Inline code beside text
+
+| Col                 | Note      |
+| ------------------- | --------- |
+| before `code` after | code span |
+
+| Col             | Note      |
+| --------------- | --------- |
+| `one` and `two` | two spans |
+
+## Autolink-style
+
+| Col                   | Note     |
+| --------------------- | -------- |
+| <https://example.com> | autolink |
+
+| Col                      | Note          |
+| ------------------------ | ------------- |
+| <mailto:dev@example.com> | mail autolink |
+
+## Strikethrough whole cell
+
+| Col      | Note   |
+| -------- | ------ |
+| ~~gone~~ | delete |
+
+## Pipes and escapes inside cells
+
+| Col             | Note         |
+| --------------- | ------------ |
+| use \| in prose | escaped pipe |
+
+GFM treats every unescaped `|` on a table line as a column boundary. The header row, separator row, and body rows must all use the **same** number of columns, or remark will not parse a `table` at all and this extension will not apply the table decoration set.
+
+**Three cells from raw pipes (not one code span):** the row below is valid GFM with three columns. The two `|` characters inside what looks like code are cell separators, so each cell is plain text (not `inlineCode` in the AST).
+
+| Col | Note | Third            |
+| --- | ---- | ---------------- |
+| `   | `    | pipe inside code |
+
+**One cell with pipes inside inline code:** escape each `|` as `\|` inside the code span.
+
+| Col           | Note                                |
+| ------------- | ----------------------------------- |
+| `a \| b \| c` | code with escaped pipes in one cell |
+
+## Long and dense cells
+
+| Col                                                  | Note     |
+| ---------------------------------------------------- | -------- |
+| https://example.com/path/to/resource?query=1&other=2 | long URL |
+
+| Col                                  | Note       |
+| ------------------------------------ | ---------- |
+| abcdefghijklmnopqrstuvwxyz0123456789 | long token |
+
+## Symmetric padding check
+
+| Header | Second |
+| ------ | ------ |
+| plain  | plain  |
+
+## Many data rows
+
+| Idx | Val |
+| --- | --- |
+| 1   | a   |
+| 2   | b   |
+| 3   | c   |
+| 4   | d   |
+| 5   | e   |
+| 6   | f   |
+
+## Multi-row stress
+
+| H1  | H2  | H3  |
+| --- | --- | --- |
+| a   | b   | c   |
+| d   | e   | f   |
+| g   | h   | i   |
+
+## Tables near other blocks
+
+Paragraph immediately above a table (blank line separates them).
+
+| After | Para |
+| ----- | ---- |
+| yes   | ok   |
+
+> Blockquote before table
+
+| After | Quote |
+| ----- | ----- |
+| yes   | ok    |
+
+- List item before table
+
+| After | List |
+| ----- | ---- |
+| yes   | ok   |

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -188,6 +188,16 @@ export function CodeDecorationType(
 }
 
 /**
+ * Default inline-code background overlay when no explicit background is configured
+ * (same formula as {@link CodeDecorationType} with `backgroundColor` omitted).
+ */
+export function defaultInlineCodeOverlayBackground(): string {
+  return isDarkTheme()
+    ? `rgba(255, 255, 255, ${BRIGHTNESS_OVERLAY_OPACITY})`
+    : `rgba(0, 0, 0, ${BRIGHTNESS_OVERLAY_OPACITY})`;
+}
+
+/**
  * Creates a decoration type for code block styling.
  *
  * @returns {vscode.TextEditorDecorationType} A decoration type for code blocks
@@ -625,6 +635,20 @@ export function TableCellDecorationType() {
     textDecoration: 'none; display: none;',
     before: {
       contentText: '',
+    },
+    // Empty after helps relayout after display:none (same idea as hide decorations).
+    after: {
+      contentText: '',
+    },
+  });
+}
+
+/** NBSP pad for rich cells where source must stay visible (not display:none). */
+export function TableCellNativePadDecorationType() {
+  return window.createTextEditorDecorationType({
+    before: {
+      contentText: '',
+      color: new ThemeColor('editor.foreground'),
     },
   });
 }

--- a/src/decorator/__tests__/visibility-model.test.ts
+++ b/src/decorator/__tests__/visibility-model.test.ts
@@ -7,7 +7,8 @@ vi.mock('../../parser', () => ({
 import { filterDecorationsForEditor } from '../visibility-model';
 import type { ScopeEntry } from '../visibility-model';
 import type { DecorationRange } from '../../parser';
-import { TextDocument, TextEditor, Selection, Position, Uri, Range } from '../../test/__mocks__/vscode';
+import { defaultInlineCodeOverlayBackground } from '../../decorations';
+import { TextDocument, TextEditor, Selection, Position, Uri, Range, ThemeColor } from '../../test/__mocks__/vscode';
 
 function makeEditor(text: string, cursorLine: number, cursorChar: number) {
   const doc = new TextDocument(Uri.file('test.md'), 'markdown', 1, text);
@@ -26,12 +27,23 @@ function simpleRangeFactory(startPos: number, endPos: number, text: string) {
   return new Range(doc.positionAt(startPos), doc.positionAt(endPos)) as any;
 }
 
+/** Filtered table/emoji entries use `renderOptions.before` (not plain `Range`). */
+function beforeAttachment(
+  item: unknown,
+): { contentText?: string; width?: string; fontWeight?: string } | undefined {
+  if (!item || typeof item !== 'object' || !('renderOptions' in item)) {
+    return undefined;
+  }
+  const ro = (item as { renderOptions?: { before?: Record<string, unknown> } }).renderOptions;
+  return ro?.before as { contentText?: string; width?: string; fontWeight?: string } | undefined;
+}
+
 describe('emoji decoration', () => {
   it('renders emoji replacement when cursor is not on the emoji line', () => {
     const text = ':smile:\nother line';
-    const decs: DecorationRange[] = [
-      { startPos: 0, endPos: 7, type: 'emoji', emoji: '😊' } as any,
-    ];
+    const decs = [
+      { startPos: 0, endPos: 7, type: 'emoji' as const, emoji: '😊' },
+    ] satisfies DecorationRange[];
     const editor = makeEditor(text, 1, 0); // cursor on line 1, not line 0
     const result = filterDecorationsForEditor(
       editor as any,
@@ -40,17 +52,17 @@ describe('emoji decoration', () => {
       text,
       (s, e, t) => simpleRangeFactory(s, e, t),
     );
-    const emojis = result.get('emoji') as any[];
+    const emojis = result.get('emoji');
     expect(emojis).toBeDefined();
-    expect(emojis.length).toBe(1);
-    expect((emojis[0] as any).renderOptions?.before?.contentText).toBe('😊');
+    expect(emojis!.length).toBe(1);
+    expect(beforeAttachment(emojis![0])?.contentText).toBe('😊');
   });
 
   it('skips emoji when cursor is inside the emoji scope (raw reveal)', () => {
     const text = ':smile:';
-    const decs: DecorationRange[] = [
-      { startPos: 0, endPos: 7, type: 'emoji', emoji: '😊' } as any,
-    ];
+    const decs = [
+      { startPos: 0, endPos: 7, type: 'emoji' as const, emoji: '😊' },
+    ] satisfies DecorationRange[];
     const doc = new TextDocument(Uri.file('test.md'), 'markdown', 1, text);
     const scope: ScopeEntry = {
       startPos: 0,
@@ -70,9 +82,7 @@ describe('emoji decoration', () => {
 
   it('does not render emoji without emoji property', () => {
     const text = ':smile:\nother';
-    const decs: DecorationRange[] = [
-      { startPos: 0, endPos: 7, type: 'emoji' } as any,
-    ];
+    const decs = [{ startPos: 0, endPos: 7, type: 'emoji' as const }] satisfies DecorationRange[];
     const editor = makeEditor(text, 1, 0);
     const result = filterDecorationsForEditor(
       editor as any,
@@ -88,9 +98,9 @@ describe('emoji decoration', () => {
 describe('table decoration rendering', () => {
   it('renders tablePipe with replacement text when cursor is off the table', () => {
     const text = '| A |\n| - |\nother';
-    const decs: DecorationRange[] = [
-      { startPos: 0, endPos: 1, type: 'tablePipe', replacement: '│' } as any,
-    ];
+    const decs = [
+      { startPos: 0, endPos: 1, type: 'tablePipe' as const, replacement: '│' },
+    ] satisfies DecorationRange[];
     const editor = makeEditor(text, 2, 0); // cursor below table on line 2
     const result = filterDecorationsForEditor(
       editor as any,
@@ -99,16 +109,39 @@ describe('table decoration rendering', () => {
       text,
       (s, e, t) => simpleRangeFactory(s, e, t),
     );
-    const pipes = result.get('tablePipe') as any[];
+    const pipes = result.get('tablePipe');
     expect(pipes).toBeDefined();
-    expect(pipes[0].renderOptions?.before?.contentText).toBe('│');
+    expect(beforeAttachment(pipes![0])?.contentText).toBe('│');
+  });
+
+  it('prepends replacementPrefix to tablePipe before content', () => {
+    const text = '| x |\nother';
+    const decs = [
+      {
+        startPos: 4,
+        endPos: 5,
+        type: 'tablePipe' as const,
+        replacement: '│',
+        replacementPrefix: '\u00A0\u00A0',
+      },
+    ] satisfies DecorationRange[];
+    const editor = makeEditor(text, 2, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const pipes = result.get('tablePipe');
+    expect(beforeAttachment(pipes![0])?.contentText).toBe('\u00A0\u00A0│');
   });
 
   it('skips table decorations when cursor is on the table (whole-block reveal)', () => {
     const text = '| A |\n| - |';
-    const decs: DecorationRange[] = [
-      { startPos: 0, endPos: 1, type: 'tablePipe', replacement: '│' } as any,
-    ];
+    const decs = [
+      { startPos: 0, endPos: 1, type: 'tablePipe' as const, replacement: '│' },
+    ] satisfies DecorationRange[];
     const doc = new TextDocument(Uri.file('test.md'), 'markdown', 1, text);
     const tableScope: ScopeEntry = {
       startPos: 0,
@@ -129,15 +162,15 @@ describe('table decoration rendering', () => {
 
   it('renders tableCell with cellStyle properties', () => {
     const text = '| **bold** |\nother';
-    const decs: DecorationRange[] = [
+    const decs = [
       {
         startPos: 0,
         endPos: 1,
-        type: 'tableCell',
+        type: 'tableCell' as const,
         replacement: ' bold ',
         cellStyle: { fontWeight: 'bold', fontStyle: 'normal', textDecoration: 'none' },
-      } as any,
-    ];
+      },
+    ] satisfies DecorationRange[];
     const editor = makeEditor(text, 1, 0);
     const result = filterDecorationsForEditor(
       editor as any,
@@ -146,19 +179,117 @@ describe('table decoration rendering', () => {
       text,
       (s, e, t) => simpleRangeFactory(s, e, t),
     );
-    const cells = result.get('tableCell') as any[];
+    const cells = result.get('tableCell');
     expect(cells).toBeDefined();
-    expect(cells[0].renderOptions?.before?.contentText).toBe(' bold ');
-    expect(cells[0].renderOptions?.before?.fontWeight).toBe('bold');
+    const before = beforeAttachment(cells![0]);
+    expect(before?.contentText).toBe(' bold ');
+    expect(before?.fontWeight).toBe('bold');
+  });
+
+  it('uses textPreformat theme colors on tableCell when cellStyle.useTextPreformatColors is set', () => {
+    const text = '| x |\nother';
+    const decs = [
+      {
+        startPos: 1,
+        endPos: 4,
+        type: 'tableCell' as const,
+        replacement: '\u00A0code\u00A0',
+        tableCellWidthCh: 8,
+        cellStyle: { useTextPreformatColors: true },
+      },
+    ] satisfies DecorationRange[];
+    const editor = makeEditor(text, 1, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const cells = result.get('tableCell');
+    const before = beforeAttachment(cells![0]);
+    expect((before?.color as InstanceType<typeof ThemeColor>).id).toBe('textPreformat.foreground');
+    expect(before?.backgroundColor).toBe(defaultInlineCodeOverlayBackground());
+  });
+
+  it('sets width in ch on tableCell before attachment when tableCellWidthCh is set', () => {
+    const text = '| x |\nother';
+    const decs = [
+      {
+        startPos: 1,
+        endPos: 4,
+        type: 'tableCell' as const,
+        replacement: '\u00A0x\u00A0\u00A0',
+        tableCellWidthCh: 7,
+      },
+    ] satisfies DecorationRange[];
+    const editor = makeEditor(text, 1, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const cells = result.get('tableCell');
+    expect(beforeAttachment(cells![0])?.width).toBe('7ch');
+    expect(beforeAttachment(cells![0])?.color).toBeDefined();
+  });
+
+  it('does not set before.width on tableCell when tableCellWidthCh is omitted', () => {
+    const text = '| x |\nother';
+    const decs = [
+      {
+        startPos: 1,
+        endPos: 4,
+        type: 'tableCell' as const,
+        replacement: '\u00A0x\u00A0\u00A0',
+      },
+    ] satisfies DecorationRange[];
+    const editor = makeEditor(text, 1, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const cells = result.get('tableCell');
+    expect(beforeAttachment(cells![0])?.width).toBeUndefined();
+  });
+
+  it('skips tableCellNativePad when cursor is on the table', () => {
+    const text = '| A |\n| - |';
+    const decs = [
+      {
+        startPos: 5,
+        endPos: 5,
+        type: 'tableCellNativePad' as const,
+        replacement: '\u00A0\u00A0',
+      },
+    ] satisfies DecorationRange[];
+    const tableScope: ScopeEntry = {
+      startPos: 0,
+      endPos: 11,
+      range: new Range(new Position(0, 0), new Position(1, 5)) as any,
+      kind: 'table',
+    };
+    const editor = makeEditor(text, 0, 2);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [tableScope],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    expect(result.has('tableCellNativePad')).toBe(false);
   });
 });
 
 describe('selection overlay for codeBlock/frontmatter', () => {
   it('adds selectionOverlay when non-empty selection covers a codeBlock', () => {
     const text = '```\ncode\n```';
-    const decs: DecorationRange[] = [
-      { startPos: 0, endPos: 12, type: 'codeBlock' } as any,
-    ];
+    const decs = [{ startPos: 0, endPos: 12, type: 'codeBlock' as const }] satisfies DecorationRange[];
     const editor = makeEditorWithSelection(text, 0, 0, 2, 3); // non-empty selection
     const result = filterDecorationsForEditor(
       editor as any,
@@ -172,9 +303,7 @@ describe('selection overlay for codeBlock/frontmatter', () => {
 
   it('adds selectionOverlay when selection covers frontmatter', () => {
     const text = '---\ntitle: hi\n---';
-    const decs: DecorationRange[] = [
-      { startPos: 0, endPos: 17, type: 'frontmatter' } as any,
-    ];
+    const decs = [{ startPos: 0, endPos: 17, type: 'frontmatter' as const }] satisfies DecorationRange[];
     const editor = makeEditorWithSelection(text, 0, 0, 1, 5); // non-empty selection
     const result = filterDecorationsForEditor(
       editor as any,
@@ -188,9 +317,7 @@ describe('selection overlay for codeBlock/frontmatter', () => {
 
   it('does not add selectionOverlay when there is no selection (cursor only)', () => {
     const text = '```\ncode\n```';
-    const decs: DecorationRange[] = [
-      { startPos: 0, endPos: 12, type: 'codeBlock' } as any,
-    ];
+    const decs = [{ startPos: 0, endPos: 12, type: 'codeBlock' as const }] satisfies DecorationRange[];
     const editor = makeEditor(text, 1, 2); // cursor-only (isEmpty)
     const result = filterDecorationsForEditor(
       editor as any,
@@ -324,11 +451,11 @@ describe('filterDecorationsForEditor — basic cases', () => {
 
   it('applies non-marker semantic decorations on non-active lines', () => {
     const text = 'hello\n**bold**';
-    const decs: DecorationRange[] = [
-      { startPos: 6, endPos: 8, type: 'hide' } as any,
-      { startPos: 8, endPos: 12, type: 'bold' } as any,
-      { startPos: 12, endPos: 14, type: 'hide' } as any,
-    ];
+    const decs = [
+      { startPos: 6, endPos: 8, type: 'hide' as const },
+      { startPos: 8, endPos: 12, type: 'bold' as const },
+      { startPos: 12, endPos: 14, type: 'hide' as const },
+    ] satisfies DecorationRange[];
     const editor = makeEditor(text, 0, 0); // cursor on line 0, decoration on line 1
     const result = filterDecorationsForEditor(
       editor as any,

--- a/src/decorator/decoration-type-registry.ts
+++ b/src/decorator/decoration-type-registry.ts
@@ -35,6 +35,7 @@ import {
   TableSeparatorPipeDecorationType,
   TableSeparatorDashDecorationType,
   TableCellDecorationType,
+  TableCellNativePadDecorationType,
 } from '../decorations';
 import type { DecorationType } from '../parser';
 
@@ -96,6 +97,7 @@ export class DecorationTypeRegistry {
   private tableSeparatorPipeDecorationType!: TextEditorDecorationType;
   private tableSeparatorDashDecorationType!: TextEditorDecorationType;
   private tableCellDecorationType!: TextEditorDecorationType;
+  private tableCellNativePadDecorationType!: TextEditorDecorationType;
 
   private decorationTypeMap = new Map<DecorationType, TextEditorDecorationType>();
 
@@ -138,6 +140,7 @@ export class DecorationTypeRegistry {
     this.tableSeparatorPipeDecorationType = TableSeparatorPipeDecorationType();
     this.tableSeparatorDashDecorationType = TableSeparatorDashDecorationType();
     this.tableCellDecorationType = TableCellDecorationType();
+    this.tableCellNativePadDecorationType = TableCellNativePadDecorationType();
 
     this.decorationTypeMap = new Map<DecorationType, TextEditorDecorationType>([
       ['hide', this.hideDecorationType],
@@ -173,6 +176,7 @@ export class DecorationTypeRegistry {
       ['tableSeparatorPipe', this.tableSeparatorPipeDecorationType],
       ['tableSeparatorDash', this.tableSeparatorDashDecorationType],
       ['tableCell', this.tableCellDecorationType],
+      ['tableCellNativePad', this.tableCellNativePadDecorationType],
       // Keep this last so it is applied after backgrounds.
       ['selectionOverlay', this.selectionOverlayDecorationType],
     ]);

--- a/src/decorator/editor-decoration-applier.ts
+++ b/src/decorator/editor-decoration-applier.ts
@@ -75,6 +75,7 @@ export function applyFilteredDecorations(
 ): void {
   const renderOptionsTypes = new Set<DecorationType>([
     'emoji', 'orderedListItem', 'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableCell',
+    'tableCellNativePad',
   ]);
 
   for (const [type, decorationType] of decorationTypes.getMap().entries()) {

--- a/src/decorator/visibility-model.ts
+++ b/src/decorator/visibility-model.ts
@@ -1,5 +1,16 @@
-import { Range, ThemeColor, type DecorationOptions, type Position, type TextEditor } from 'vscode';
+import {
+  Range,
+  ThemeColor,
+  workspace,
+  type DecorationOptions,
+  type Position,
+  type TextEditor,
+  type ThemableDecorationAttachmentRenderOptions,
+  type ThemableDecorationInstanceRenderOptions,
+} from 'vscode';
 import type { DecorationRange, DecorationType } from '../parser';
+import { config } from '../config';
+import { defaultInlineCodeOverlayBackground } from '../decorations';
 import { isMarkerDecorationType } from './decoration-categories';
 
 export type ScopeEntry = {
@@ -11,6 +22,13 @@ export type ScopeEntry = {
 
 type RangeFactory = (startPos: number, endPos: number, originalText: string) => Range | null;
 type FilteredDecoration = Range | DecorationOptions;
+
+type TableCellBeforeAttachmentOptions = ThemableDecorationAttachmentRenderOptions & {
+  /** Supported at runtime for `before` attachments; omitted from older @types/vscode. */
+  fontFamily?: string;
+  /** Supported at runtime for inline-code-style table cells. */
+  backgroundColor?: string | ThemeColor;
+};
 
 export function filterDecorationsForEditor(
   editor: TextEditor,
@@ -67,6 +85,7 @@ export function filterDecorationsForEditor(
   // Table decoration types that use per-range replacement rendering
   const tableTypes = new Set<DecorationType>([
     'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableCell',
+    'tableCellNativePad',
   ]);
 
   // For table blocks, if cursor/selection is on ANY line in the table,
@@ -206,19 +225,49 @@ export function filterDecorationsForEditor(
       }
       if (decoration.replacement !== undefined) {
         const ranges = filtered.get(decoration.type) || [];
-        const beforeOpts: Record<string, unknown> = {
-          contentText: decoration.replacement,
+        const pipePrefix =
+          decoration.type === 'tablePipe' && decoration.replacementPrefix
+            ? decoration.replacementPrefix
+            : '';
+        const beforeOpts: TableCellBeforeAttachmentOptions = {
+          contentText: pipePrefix + decoration.replacement,
         };
-        if (decoration.cellStyle) {
-          if (decoration.cellStyle.fontWeight) beforeOpts.fontWeight = decoration.cellStyle.fontWeight;
-          if (decoration.cellStyle.fontStyle) beforeOpts.fontStyle = decoration.cellStyle.fontStyle;
-          if (decoration.cellStyle.textDecoration) beforeOpts.textDecoration = decoration.cellStyle.textDecoration;
+        if (decoration.type === 'tableCell') {
+          const ch = decoration.tableCellWidthCh;
+          if (ch !== undefined && ch > 0) {
+            beforeOpts.width = `${ch}ch`;
+          }
+          const editorFont = workspace
+            .getConfiguration('editor', editor.document.uri)
+            .get<string>('fontFamily');
+          if (editorFont) {
+            beforeOpts.fontFamily = editorFont;
+          }
+          if (decoration.cellStyle?.useTextPreformatColors === true) {
+            const cfgFg = config.colors.inlineCode();
+            const cfgBg = config.colors.inlineCodeBackground();
+            beforeOpts.color =
+              cfgFg !== undefined ? cfgFg : new ThemeColor('textPreformat.foreground');
+            beforeOpts.backgroundColor =
+              cfgBg !== undefined ? cfgBg : defaultInlineCodeOverlayBackground();
+          } else {
+            beforeOpts.color = new ThemeColor('editor.foreground');
+          }
+          if (decoration.cellStyle) {
+            if (decoration.cellStyle.fontWeight) beforeOpts.fontWeight = decoration.cellStyle.fontWeight;
+            if (decoration.cellStyle.fontStyle) beforeOpts.fontStyle = decoration.cellStyle.fontStyle;
+            if (decoration.cellStyle.textDecoration) beforeOpts.textDecoration = decoration.cellStyle.textDecoration;
+          }
         }
+        const renderOptions: ThemableDecorationInstanceRenderOptions = {
+          before: beforeOpts,
+          ...(decoration.type === 'tableCell'
+            ? { after: { contentText: '' } }
+            : {}),
+        };
         ranges.push({
           range,
-          renderOptions: {
-            before: beforeOpts,
-          },
+          renderOptions,
         });
         filtered.set(decoration.type, ranges);
       }

--- a/src/parser/__tests__/parser-table.test.ts
+++ b/src/parser/__tests__/parser-table.test.ts
@@ -11,6 +11,11 @@ describe('MarkdownParser - Tables', () => {
     return decs.filter((d) => d.type === type);
   }
 
+  /** Plain cells use native pad; synthetic cells use tableCell. */
+  function tableCells(decs: DecorationRange[]) {
+    return [...byType(decs, 'tableCell'), ...byType(decs, 'tableCellNativePad')];
+  }
+
   describe('basic table rendering', () => {
     it('should create tablePipe decorations for pipe characters', () => {
       const md = '| A | B |\n|---|---|\n| 1 | 2 |';
@@ -36,16 +41,14 @@ describe('MarkdownParser - Tables', () => {
       expect(cells).toBe(9);
     });
 
-    it('should create tableCell decorations with padded replacement', () => {
+    it('should create native pad decorations with leading NBSP for plain cells', () => {
       const md = '| Name | Age |\n|------|-----|\n| Jo   | 5   |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
+      const cells = tableCells(result);
       expect(cells.length).toBeGreaterThanOrEqual(4);
       cells.forEach((c) => {
         expect(c.replacement).toBeDefined();
-        // Each cell should start and end with non-breaking space
         expect(c.replacement!.startsWith('\u00A0')).toBe(true);
-        expect(c.replacement!.endsWith('\u00A0')).toBe(true);
       });
     });
 
@@ -69,41 +72,42 @@ describe('MarkdownParser - Tables', () => {
     it('should left-align cells by default (pad right)', () => {
       const md = '| Foo | Bar |\n|-----|-----|\n| x   | y   |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      // Default alignment: content starts after one NBSP
-      const dataCell = cells.find((c) => c.replacement!.includes('x'));
-      expect(dataCell).toBeDefined();
-      // Left-aligned: starts with single NBSP then content
-      expect(dataCell!.replacement!.indexOf('x')).toBe(1);
+      const dataLineStart = md.indexOf('| x');
+      const dataPad = tableCells(result).find(
+        (c) => c.startPos >= dataLineStart && md.slice(c.startPos, c.endPos) === 'x',
+      );
+      expect(dataPad?.replacement?.startsWith('\u00A0')).toBe(true);
     });
 
     it('should right-align cells when column uses ---:', () => {
       const result = parser.extractDecorations(alignedTable);
-      const cells = byType(result, 'tableCell');
-      // Find a data row cell for the right-aligned column (column index 2, content "c")
-      const rightCell = cells.find((c) => c.replacement!.includes('c'));
-      expect(rightCell).toBeDefined();
-      // Right-aligned: content should end with single NBSP
-      expect(rightCell!.replacement!.endsWith('c\u00A0')).toBe(true);
-      // Should have leading padding
-      const leadingSpaces = rightCell!.replacement!.length - rightCell!.replacement!.trimStart().length;
-      expect(leadingSpaces).toBeGreaterThanOrEqual(1);
+      const dataLineStart = alignedTable.indexOf('| a');
+      const rightPad = tableCells(result).find(
+        (c) =>
+          c.startPos >= dataLineStart &&
+          alignedTable.slice(c.startPos, c.endPos).trim() === 'c',
+      );
+      expect(rightPad?.replacement?.startsWith('\u00A0')).toBe(true);
+      // Right-aligned columns add most padding before visible text.
+      expect((rightPad!.replacement || '').length).toBeGreaterThan(2);
     });
 
     it('should center-align cells when column uses :---:', () => {
       const result = parser.extractDecorations(alignedTable);
-      const cells = byType(result, 'tableCell');
-      // Find a data row cell for the center-aligned column (column index 1, content "b")
-      const centerCell = cells.find((c) => c.replacement!.includes('b'));
-      expect(centerCell).toBeDefined();
-      // Center-aligned: should have padding on both sides
-      const content = centerCell!.replacement!;
-      const trimmed = content.replace(/\u00A0/g, '').trim();
-      const beforeContent = content.indexOf(trimmed);
-      const afterContent = content.length - beforeContent - trimmed.length;
-      // Both sides should have at least 1 char of padding
-      expect(beforeContent).toBeGreaterThanOrEqual(1);
-      expect(afterContent).toBeGreaterThanOrEqual(1);
+      const dataLineStart = alignedTable.indexOf('| a');
+      const centerPad = tableCells(result).find(
+        (c) =>
+          c.startPos >= dataLineStart &&
+          alignedTable.slice(c.startPos, c.endPos).trim() === 'b',
+      );
+      expect(centerPad?.replacement?.startsWith('\u00A0')).toBe(true);
+      const closingPipe = result.find(
+        (d) =>
+          d.type === 'tablePipe' &&
+          d.startPos > centerPad!.endPos &&
+          (d.replacementPrefix?.length ?? 0) > 1,
+      );
+      expect(closingPipe).toBeDefined();
     });
   });
 
@@ -111,41 +115,40 @@ describe('MarkdownParser - Tables', () => {
     it('should account for CJK double-width in column padding', () => {
       const md = '| Name | CJK  |\n|------|------|\n| AB   | \u4F60\u597D   |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      // All cells should have replacement text
-      cells.forEach((c) => {
+      tableCells(result).forEach((c) => {
         expect(c.replacement).toBeDefined();
       });
     });
 
     it('treats single emoji as wide so column reserves 2 columns', () => {
-      // Header "Emoji" width 5; data cell holds one emoji (width 2).
-      // Without wide-emoji support the data cell would be padded as if width 1.
       const md = '| Emoji |\n|-------|\n| \uD83D\uDE00 |';
       const result = parser.extractDecorations(md);
-      const dataCell = byType(result, 'tableCell').find((c) =>
-        c.replacement?.includes('\uD83D\uDE00'),
+      const dataLineStart = md.indexOf('\uD83D\uDE00');
+      const emojiPad = tableCells(result).find(
+        (c) =>
+          c.startPos >= dataLineStart &&
+          md.slice(c.startPos, c.endPos).includes('\uD83D\uDE00'),
       );
-      expect(dataCell).toBeDefined();
-      // Replacement is "\u00A0" + content + "\u00A0".repeat(totalPad+1).
-      // Without wide-emoji handling, totalPad would be header-1=4 → 6 trailing NBSP.
-      // With wide-emoji handling, totalPad=header-2=3 → 5 trailing NBSP.
-      const trailing = (dataCell!.replacement || '').match(/\u00A0+$/)?.[0] || '';
-      expect(trailing.length).toBeLessThanOrEqual(5);
+      expect(emojiPad).toBeDefined();
+      const closingPipe = result.find(
+        (d) =>
+          d.type === 'tablePipe' &&
+          d.startPos > emojiPad!.endPos &&
+          (d.replacementPrefix?.length ?? 0) >= 4,
+      );
+      expect(closingPipe).toBeDefined();
     });
 
     it('counts ZWJ-joined emoji sequences using single combined width', () => {
-      // 👨‍👩‍👧 (man + ZWJ + woman + ZWJ + girl) renders as one wide glyph.
-      // Without ZWJ handling we'd over-count to 6 (3 emoji × 2).
       const family = '\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67';
       const md = `| Emoji |\n|-------|\n| ${family} |`;
       const result = parser.extractDecorations(md);
-      const dataCell = byType(result, 'tableCell').find((c) =>
-        c.replacement?.includes(family),
+      const dataLineStart = md.indexOf(family);
+      const familyPad = tableCells(result).find(
+        (c) => c.startPos >= dataLineStart && md.slice(c.startPos, c.endPos).includes(family),
       );
-      expect(dataCell).toBeDefined();
-      // Total padding stays small; replacement length should be modest, not blown up.
-      expect((dataCell!.replacement || '').length).toBeLessThanOrEqual(12);
+      expect(familyPad).toBeDefined();
+      expect((familyPad!.replacement || '').length).toBeLessThanOrEqual(4);
     });
   });
 
@@ -183,15 +186,16 @@ describe('MarkdownParser - Tables', () => {
       expect(pads.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('strips markers from width for synthetic cells (plain data row)', () => {
+    it('uses equal native leading pad width for plain header and data cells', () => {
       const md = '| Header   |\n|----------|\n| plain    |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      const dataCell = cells.find((c) => c.replacement!.includes('plain'));
-      const headerCell = cells.find((c) => c.replacement!.includes('Header'));
-      expect(dataCell).toBeDefined();
-      expect(headerCell).toBeDefined();
-      expect(dataCell!.replacement!.length).toBe(headerCell!.replacement!.length);
+      const headerPad = tableCells(result).find((c) =>
+        md.slice(c.startPos, c.endPos).includes('Header'),
+      );
+      const dataPad = tableCells(result).find((c) =>
+        md.slice(c.startPos, c.endPos).includes('plain'),
+      );
+      expect(headerPad?.replacement?.length).toBe(dataPad?.replacement?.length);
     });
   });
 
@@ -199,15 +203,13 @@ describe('MarkdownParser - Tables', () => {
     it('should handle empty cells', () => {
       const md = '| A |   |\n|---|---|\n|   | B |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      expect(cells.length).toBeGreaterThanOrEqual(4);
+      expect(tableCells(result).length).toBeGreaterThanOrEqual(4);
     });
 
     it('should handle single-column table', () => {
       const md = '| A |\n|---|\n| B |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      expect(cells.length).toBeGreaterThanOrEqual(2);
+      expect(tableCells(result).length).toBeGreaterThanOrEqual(2);
     });
   });
 
@@ -215,7 +217,7 @@ describe('MarkdownParser - Tables', () => {
     it('should render outer-pipe-less table when it starts at document offset 0', () => {
       const md = 'A | B\n---|---\n1 | 2';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
+      const cells = tableCells(result);
       const pipes = byType(result, 'tablePipe');
       expect(cells.length).toBeGreaterThanOrEqual(4);
       expect(cells.every((c) => c.startPos >= 0 && c.endPos > c.startPos)).toBe(true);
@@ -228,8 +230,7 @@ describe('MarkdownParser - Tables', () => {
     it('should render cells when table has no outer pipes', () => {
       const md = 'A | B\n---|---\n1 | 2';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      expect(cells.length).toBeGreaterThanOrEqual(4);
+      expect(tableCells(result).length).toBeGreaterThanOrEqual(4);
     });
 
     it('should render separator for outer-pipe-less table', () => {
@@ -300,7 +301,7 @@ describe('MarkdownParser - Tables', () => {
       expect(byType(result, 'tablePipe').length).toBeGreaterThan(0);
       const dashes = byType(result, 'tableSeparatorDash');
       const firstColDash = dashes[0]?.replacement ?? '';
-      expect(firstColDash.length).toBe(18);
+      expect(firstColDash.length).toBeGreaterThanOrEqual(11);
     });
   });
 
@@ -308,17 +309,19 @@ describe('MarkdownParser - Tables', () => {
     it('should not strip underscores from snake_case cell content', () => {
       const md = '| Field |\n|-------|\n| snake_case |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      const snakeCell = cells.find((c) => c.replacement!.includes('snake_case'));
-      expect(snakeCell).toBeDefined();
+      const snakePad = tableCells(result).find((c) =>
+        md.slice(c.startPos, c.endPos).includes('snake_case'),
+      );
+      expect(snakePad).toBeDefined();
     });
 
     it('should not strip asterisks from arithmetic expressions', () => {
       const md = '| Expr |\n|------|\n| 100*200 |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      const exprCell = cells.find((c) => c.replacement!.includes('100'));
-      expect(exprCell).toBeDefined();
+      const exprPad = tableCells(result).find((c) =>
+        md.slice(c.startPos, c.endPos).includes('100'),
+      );
+      expect(exprPad).toBeDefined();
     });
   });
 
@@ -343,41 +346,39 @@ describe('MarkdownParser - Tables', () => {
       const result = parser.extractDecorations(md);
       expect(byType(result, 'tablePipe').length).toBeGreaterThan(0);
       const dataLineStart = md.indexOf('| `');
-      const rowCells = byType(result, 'tableCell')
+      const rowCells = tableCells(result)
         .filter((c) => c.startPos >= dataLineStart)
         .sort((a, b) => a.startPos - b.startPos);
       expect(rowCells.length).toBe(3);
-      for (const c of rowCells) {
-        expect(c.replacement).toBeDefined();
-        expect(c.replacement!.includes('bb')).toBe(false);
-      }
-      expect(rowCells[0].replacement!.includes('`')).toBe(true);
-      expect(rowCells[1].replacement!.includes('`')).toBe(true);
-      expect(rowCells[2].replacement!).toContain('pipe inside code');
+      expect(md.slice(rowCells[0].startPos, rowCells[0].endPos).trim()).toBe('`');
+      expect(md.slice(rowCells[1].startPos, rowCells[1].endPos).trim()).toBe('`');
+      expect(md.slice(rowCells[2].startPos, rowCells[2].endPos)).toContain('pipe');
     });
 
     it('uses synthetic padded cell for whole-cell inline code (grid aligns with pipes)', () => {
       const md = '| C |\n|---|\n| `x` |';
       const result = parser.extractDecorations(md);
-      expect(byType(result, 'tableCellNativePad').length).toBe(0);
-      const cells = byType(result, 'tableCell');
-      expect(cells.length).toBeGreaterThanOrEqual(2);
-      expect(cells.some((c) => c.replacement?.includes('x'))).toBe(true);
-      expect(cells.some((c) => c.replacement?.includes('`'))).toBe(false);
+      const synthetic = byType(result, 'tableCell');
+      const nativePads = byType(result, 'tableCellNativePad');
+      expect(synthetic.length).toBeGreaterThanOrEqual(1);
+      expect(synthetic.some((c) => c.replacement?.includes('x'))).toBe(true);
+      expect(nativePads.some((c) => md.slice(c.startPos, c.endPos) === 'C')).toBe(true);
     });
 
-    it('two-column table with inline code in one cell uses no native pad', () => {
+    it('two-column table with inline code in one cell uses synthetic tableCell', () => {
       const md = [
         '| Col    | Note            |',
         '| ------ | --------------- |',
         '| `code` | whole-cell code |',
       ].join('\n');
       const result = parser.extractDecorations(md);
-      expect(byType(result, 'tableCellNativePad').length).toBe(0);
       const codeCell = byType(result, 'tableCell').find((c) =>
         c.replacement?.includes('code') && !c.replacement?.includes('whole'),
       );
       expect(codeCell?.cellStyle?.useTextPreformatColors).toBe(true);
+      expect(
+        tableCells(result).some((c) => md.slice(c.startPos, c.endPos).includes('whole')),
+      ).toBe(true);
     });
 
     it('keeps plain and inline-code data cells on distinct source ranges', () => {
@@ -400,31 +401,39 @@ describe('MarkdownParser - Tables', () => {
       expect(md.slice(rowCells[2].startPos, rowCells[2].endPos)).toContain('pipe');
     });
 
-    it('uses synthetic tableCell for plain cells only', () => {
+    it('uses native pad for plain cells so source stays clickable', () => {
       const md = '| P |\n|---|\n| plain |';
       const result = parser.extractDecorations(md);
-      expect(byType(result, 'tableCellNativePad').length).toBe(0);
-      const cells = byType(result, 'tableCell');
-      expect(cells.length).toBeGreaterThanOrEqual(2);
-      cells.forEach((c) => {
+      expect(byType(result, 'tableCell').length).toBe(0);
+      const pads = byType(result, 'tableCellNativePad');
+      expect(pads.length).toBeGreaterThanOrEqual(2);
+      pads.forEach((c) => {
         expect(c.replacement!.startsWith('\u00A0')).toBe(true);
       });
+    });
+
+    it('scopes plain native pad to trimmed source and hides GFM padding spaces', () => {
+      const md = '| Name | Age |\n|------|-----|\n| Jo   | 5   |';
+      const result = parser.extractDecorations(md);
+      const joPad = tableCells(result).find(
+        (c) => md.slice(c.startPos, c.endPos) === 'Jo',
+      );
+      expect(joPad).toBeDefined();
+      const dataLineStart = md.indexOf('| Jo');
+      const hides = result.filter(
+        (d) => d.type === 'hide' && d.startPos >= dataLineStart,
+      );
+      expect(hides.length).toBeGreaterThanOrEqual(2);
     });
   });
 
   describe('tableCellWidthCh (synthetic cell grid)', () => {
-    it('sets tableCellWidthCh on every synthetic cell for CJK and emoji columns', () => {
-      const md = [
-        '| Name | CJK | Emoji |',
-        '| ---- | ---- | ----- |',
-        '| AB | 你好 | 😀 |',
-        '| CD | 世界 | 🚀 |',
-      ].join('\n');
+    it('sets tableCellWidthCh on synthetic whole-cell inline code cells', () => {
+      const md = '| Col |\n|-----|\n| `xy` |';
       const result = parser.extractDecorations(md);
       const synthetic = byType(result, 'tableCell').filter((c) => c.tableCellWidthCh !== undefined);
-      expect(synthetic.length).toBeGreaterThanOrEqual(8);
+      expect(synthetic.length).toBeGreaterThanOrEqual(1);
       synthetic.forEach((c) => {
-        expect(typeof c.tableCellWidthCh).toBe('number');
         expect(c.tableCellWidthCh!).toBeGreaterThan(0);
       });
     });

--- a/src/parser/__tests__/parser-table.test.ts
+++ b/src/parser/__tests__/parser-table.test.ts
@@ -298,6 +298,9 @@ describe('MarkdownParser - Tables', () => {
       const result = parser.extractDecorations(md);
       expect(byType(result, 'tableCellNativePad').length).toBeGreaterThanOrEqual(1);
       expect(byType(result, 'tablePipe').length).toBeGreaterThan(0);
+      const dashes = byType(result, 'tableSeparatorDash');
+      const firstColDash = dashes[0]?.replacement ?? '';
+      expect(firstColDash.length).toBe(18);
     });
   });
 

--- a/src/parser/__tests__/parser-table.test.ts
+++ b/src/parser/__tests__/parser-table.test.ts
@@ -23,6 +23,19 @@ describe('MarkdownParser - Tables', () => {
       });
     });
 
+    it('emits one cell decoration per column for each non-separator row (three-column)', () => {
+      const md = [
+        '| aa | bb | cc |',
+        '| -- | -- | -- |',
+        '| 11 | 22 | 33 |',
+        '| 44 | 55 | 66 |',
+      ].join('\n');
+      const result = parser.extractDecorations(md);
+      const cells =
+        byType(result, 'tableCell').length + byType(result, 'tableCellNativePad').length;
+      expect(cells).toBe(9);
+    });
+
     it('should create tableCell decorations with padded replacement', () => {
       const md = '| Name | Age |\n|------|-----|\n| Jo   | 5   |';
       const result = parser.extractDecorations(md);
@@ -104,40 +117,81 @@ describe('MarkdownParser - Tables', () => {
         expect(c.replacement).toBeDefined();
       });
     });
+
+    it('treats single emoji as wide so column reserves 2 columns', () => {
+      // Header "Emoji" width 5; data cell holds one emoji (width 2).
+      // Without wide-emoji support the data cell would be padded as if width 1.
+      const md = '| Emoji |\n|-------|\n| \uD83D\uDE00 |';
+      const result = parser.extractDecorations(md);
+      const dataCell = byType(result, 'tableCell').find((c) =>
+        c.replacement?.includes('\uD83D\uDE00'),
+      );
+      expect(dataCell).toBeDefined();
+      // Replacement is "\u00A0" + content + "\u00A0".repeat(totalPad+1).
+      // Without wide-emoji handling, totalPad would be header-1=4 → 6 trailing NBSP.
+      // With wide-emoji handling, totalPad=header-2=3 → 5 trailing NBSP.
+      const trailing = (dataCell!.replacement || '').match(/\u00A0+$/)?.[0] || '';
+      expect(trailing.length).toBeLessThanOrEqual(5);
+    });
+
+    it('counts ZWJ-joined emoji sequences using single combined width', () => {
+      // 👨‍👩‍👧 (man + ZWJ + woman + ZWJ + girl) renders as one wide glyph.
+      // Without ZWJ handling we'd over-count to 6 (3 emoji × 2).
+      const family = '\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67';
+      const md = `| Emoji |\n|-------|\n| ${family} |`;
+      const result = parser.extractDecorations(md);
+      const dataCell = byType(result, 'tableCell').find((c) =>
+        c.replacement?.includes(family),
+      );
+      expect(dataCell).toBeDefined();
+      // Total padding stays small; replacement length should be modest, not blown up.
+      expect((dataCell!.replacement || '').length).toBeLessThanOrEqual(12);
+    });
   });
 
   describe('inline formatting in cells', () => {
-    it('should detect bold cell style', () => {
+    it('uses native cell for whole-cell strong so source stays visible', () => {
       const md = '| A |\n|---|\n| **bold** |';
       const result = parser.extractDecorations(md);
       const cells = byType(result, 'tableCell');
-      const boldCell = cells.find((c) => c.cellStyle?.fontWeight === 'bold');
-      expect(boldCell).toBeDefined();
-      // replacement should not contain ** markers
-      expect(boldCell!.replacement).not.toContain('**');
-      expect(boldCell!.replacement).toContain('bold');
+      const pads = byType(result, 'tableCellNativePad');
+      expect(cells.some((c) => c.cellStyle?.fontWeight === 'bold')).toBe(false);
+      expect(cells.some((c) => c.replacement?.includes('**'))).toBe(false);
+      expect(pads.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('should detect italic cell style', () => {
+    it('merges trailing native pad into closing tablePipe replacementPrefix', () => {
+      const md = '| A |\n|---|\n| **BB** |';
+      const result = parser.extractDecorations(md);
+      const pads = byType(result, 'tableCellNativePad');
+      const cells = byType(result, 'tableCell');
+      expect(pads.length).toBeGreaterThanOrEqual(1);
+      expect(cells.some((c) => c.replacement?.includes('BB'))).toBe(false);
+      const dataPad = pads[pads.length - 1];
+      const closingPipe = result.find(
+        (d) => d.type === 'tablePipe' && d.startPos === dataPad!.endPos,
+      );
+      expect(closingPipe?.replacementPrefix).toBe('\u00A0');
+    });
+
+    it('uses native cell for whole-cell emphasis', () => {
       const md = '| A |\n|---|\n| *italic* |';
       const result = parser.extractDecorations(md);
       const cells = byType(result, 'tableCell');
-      const italicCell = cells.find((c) => c.cellStyle?.fontStyle === 'italic');
-      expect(italicCell).toBeDefined();
+      const pads = byType(result, 'tableCellNativePad');
+      expect(cells.some((c) => c.cellStyle?.fontStyle === 'italic')).toBe(false);
+      expect(pads.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('should strip markers from width calculation', () => {
-      const md = '| Header   |\n|----------|\n| **bold** |';
+    it('strips markers from width for synthetic cells (plain data row)', () => {
+      const md = '| Header   |\n|----------|\n| plain    |';
       const result = parser.extractDecorations(md);
       const cells = byType(result, 'tableCell');
-      // "bold" (4 chars) should be padded relative to "Header" (6 chars),
-      // not "**bold**" (8 chars)
-      const boldCell = cells.find((c) => c.replacement!.includes('bold'));
-      expect(boldCell).toBeDefined();
+      const dataCell = cells.find((c) => c.replacement!.includes('plain'));
       const headerCell = cells.find((c) => c.replacement!.includes('Header'));
+      expect(dataCell).toBeDefined();
       expect(headerCell).toBeDefined();
-      // Both replacements should be same total length (aligned columns)
-      expect(boldCell!.replacement!.length).toBe(headerCell!.replacement!.length);
+      expect(dataCell!.replacement!.length).toBe(headerCell!.replacement!.length);
     });
   });
 
@@ -197,13 +251,53 @@ describe('MarkdownParser - Tables', () => {
   });
 
   describe('links in cells', () => {
-    it('should include link label text in cell replacement', () => {
+    it('uses native cell for link so markdown link styling can apply', () => {
       const md = '| Col |\n|-----|\n| [label](https://example.com) |';
       const result = parser.extractDecorations(md);
       const cells = byType(result, 'tableCell');
-      const dataCell = cells.find((c) => c.replacement?.includes('label'));
-      expect(dataCell).toBeDefined();
-      expect(dataCell!.replacement).not.toContain('https://');
+      const pads = byType(result, 'tableCellNativePad');
+      expect(cells.some((c) => c.replacement?.includes('label'))).toBe(false);
+      expect(pads.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('images in cells', () => {
+    it('uses native cell for images and still emits a consistent pipe grid', () => {
+      const md = '| Col |\n|-----|\n| ![t](https://example.com/x.png) |';
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableCellNativePad').length).toBeGreaterThanOrEqual(1);
+      expect(byType(result, 'tablePipe').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('underscore delimiters in cells', () => {
+    it('handles whole-cell ___…___ without throwing', () => {
+      const md = '| Col |\n|-----|\n| ___x___ |';
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tablePipe').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('GFM column alignment and pipes in table rows', () => {
+    it('does not emit table decorations when header and separator column counts disagree', () => {
+      const md = [
+        '| Col | Note |',
+        '| --- | ---- | ---------------- |',
+        '| `   | `    | pipe inside code |',
+      ].join('\n');
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tablePipe').length).toBe(0);
+    });
+
+    it('keeps a pipe inside one cell when escaped inside inline code', () => {
+      const md = [
+        '| Col | Note |',
+        '| --- | ---- |',
+        '| `a \\| b \\| c`  | code with escaped pipes in one cell |',
+      ].join('\n');
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableCellNativePad').length).toBeGreaterThanOrEqual(1);
+      expect(byType(result, 'tablePipe').length).toBeGreaterThan(0);
     });
   });
 
@@ -226,16 +320,123 @@ describe('MarkdownParser - Tables', () => {
   });
 
   describe('mixed formatting fallback', () => {
-    it('should show raw syntax for mixed formatting cells', () => {
+    it('uses native cell for mixed formatting so markers are not in synthetic text', () => {
       const md = '| A |\n|---|\n| **bold** and plain |';
       const result = parser.extractDecorations(md);
       const cells = byType(result, 'tableCell');
-      const mixedCell = cells.find((c) => c.replacement!.includes('bold'));
-      expect(mixedCell).toBeDefined();
-      // Mixed formatting should show raw markdown syntax
-      expect(mixedCell!.replacement).toContain('**');
-      // Should NOT have cellStyle since it's mixed
-      expect(mixedCell!.cellStyle).toBeUndefined();
+      const pads = byType(result, 'tableCellNativePad');
+      expect(cells.some((c) => c.replacement?.includes('**'))).toBe(false);
+      expect(pads.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('rich vs plain table cells', () => {
+    it('GFM three-column row with backticks at cell boundaries shows backticks not stray letters', () => {
+      const md = [
+        '| Col | Note | Third |',
+        '| --- | ---- | ----- |',
+        '| `   | `    | pipe inside code |',
+      ].join('\n');
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tablePipe').length).toBeGreaterThan(0);
+      const dataLineStart = md.indexOf('| `');
+      const rowCells = byType(result, 'tableCell')
+        .filter((c) => c.startPos >= dataLineStart)
+        .sort((a, b) => a.startPos - b.startPos);
+      expect(rowCells.length).toBe(3);
+      for (const c of rowCells) {
+        expect(c.replacement).toBeDefined();
+        expect(c.replacement!.includes('bb')).toBe(false);
+      }
+      expect(rowCells[0].replacement!.includes('`')).toBe(true);
+      expect(rowCells[1].replacement!.includes('`')).toBe(true);
+      expect(rowCells[2].replacement!).toContain('pipe inside code');
+    });
+
+    it('uses synthetic padded cell for whole-cell inline code (grid aligns with pipes)', () => {
+      const md = '| C |\n|---|\n| `x` |';
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableCellNativePad').length).toBe(0);
+      const cells = byType(result, 'tableCell');
+      expect(cells.length).toBeGreaterThanOrEqual(2);
+      expect(cells.some((c) => c.replacement?.includes('x'))).toBe(true);
+      expect(cells.some((c) => c.replacement?.includes('`'))).toBe(false);
+    });
+
+    it('two-column table with inline code in one cell uses no native pad', () => {
+      const md = [
+        '| Col    | Note            |',
+        '| ------ | --------------- |',
+        '| `code` | whole-cell code |',
+      ].join('\n');
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableCellNativePad').length).toBe(0);
+      const codeCell = byType(result, 'tableCell').find((c) =>
+        c.replacement?.includes('code') && !c.replacement?.includes('whole'),
+      );
+      expect(codeCell?.cellStyle?.useTextPreformatColors).toBe(true);
+    });
+
+    it('keeps plain and inline-code data cells on distinct source ranges', () => {
+      const md = [
+        '| Col | Note | Third |',
+        '| --- | ---- | ----- |',
+        '| bb  | `x`  | pipe inside code |',
+      ].join('\n');
+      const result = parser.extractDecorations(md);
+      const dataLineStart = md.indexOf('| bb');
+      const rowCells = [
+        ...byType(result, 'tableCell'),
+        ...byType(result, 'tableCellNativePad'),
+      ]
+        .filter((c) => c.startPos >= dataLineStart)
+        .sort((a, b) => a.startPos - b.startPos);
+      expect(rowCells.length).toBe(3);
+      expect(md.slice(rowCells[0].startPos, rowCells[0].endPos)).toContain('bb');
+      expect(md.slice(rowCells[1].startPos, rowCells[1].endPos)).not.toContain('bb');
+      expect(md.slice(rowCells[2].startPos, rowCells[2].endPos)).toContain('pipe');
+    });
+
+    it('uses synthetic tableCell for plain cells only', () => {
+      const md = '| P |\n|---|\n| plain |';
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableCellNativePad').length).toBe(0);
+      const cells = byType(result, 'tableCell');
+      expect(cells.length).toBeGreaterThanOrEqual(2);
+      cells.forEach((c) => {
+        expect(c.replacement!.startsWith('\u00A0')).toBe(true);
+      });
+    });
+  });
+
+  describe('tableCellWidthCh (synthetic cell grid)', () => {
+    it('sets tableCellWidthCh on every synthetic cell for CJK and emoji columns', () => {
+      const md = [
+        '| Name | CJK | Emoji |',
+        '| ---- | ---- | ----- |',
+        '| AB | 你好 | 😀 |',
+        '| CD | 世界 | 🚀 |',
+      ].join('\n');
+      const result = parser.extractDecorations(md);
+      const synthetic = byType(result, 'tableCell').filter((c) => c.tableCellWidthCh !== undefined);
+      expect(synthetic.length).toBeGreaterThanOrEqual(8);
+      synthetic.forEach((c) => {
+        expect(typeof c.tableCellWidthCh).toBe('number');
+        expect(c.tableCellWidthCh!).toBeGreaterThan(0);
+      });
+    });
+
+    it('uses native pad for mixed emphasis in a cell without throwing', () => {
+      const md = '| Col |\n|-----|\n| a *i* z |';
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableCellNativePad').length).toBeGreaterThanOrEqual(1);
+      expect(byType(result, 'tablePipe').length).toBeGreaterThan(0);
+    });
+
+    it('uses native pad for mixed underscore emphasis in a cell', () => {
+      const md = '| Col |\n|-----|\n| a _i_ z |';
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableCellNativePad').length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/src/parser/__tests__/table-alignment-padding.test.ts
+++ b/src/parser/__tests__/table-alignment-padding.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildNativeTableCellPadParts,
+  buildSyntheticTableCellReplacement,
+  leadingTrailingNbspRepeatCounts,
+} from '../tables';
+
+const NBSP = '\u00A0';
+
+describe('table NBSP padding helpers', () => {
+  it('matches legacy left alignment counts', () => {
+    expect(leadingTrailingNbspRepeatCounts(null, 0)).toEqual({ leading: 1, trailing: 1 });
+    expect(leadingTrailingNbspRepeatCounts('left', 2)).toEqual({ leading: 1, trailing: 3 });
+  });
+
+  it('matches legacy right alignment counts', () => {
+    expect(leadingTrailingNbspRepeatCounts('right', 1)).toEqual({ leading: 2, trailing: 1 });
+  });
+
+  it('matches legacy center alignment counts', () => {
+    expect(leadingTrailingNbspRepeatCounts('center', 3)).toEqual({ leading: 2, trailing: 3 });
+  });
+
+  it('buildSyntheticTableCellReplacement matches concatenation pattern', () => {
+    const content = 'x';
+    expect(buildSyntheticTableCellReplacement(null, 0, content)).toBe(
+      NBSP + content + NBSP,
+    );
+    expect(buildSyntheticTableCellReplacement('right', 1, content)).toBe(
+      NBSP.repeat(2) + content + NBSP,
+    );
+    const padLeft = 1;
+    const padRight = 2;
+    const totalPad = 3;
+    expect(buildSyntheticTableCellReplacement('center', totalPad, content)).toBe(
+      NBSP.repeat(padLeft + 1) + content + NBSP.repeat(padRight + 1),
+    );
+  });
+
+  it('buildNativeTableCellPadParts splits like synthetic sides', () => {
+    const syn = buildSyntheticTableCellReplacement('center', 4, 'hi');
+    const native = buildNativeTableCellPadParts('center', 4);
+    expect(native.leadingNbsp + 'hi' + native.trailingNbsp).toBe(syn);
+  });
+});

--- a/src/parser/__tests__/table-cell-hidden-length.test.ts
+++ b/src/parser/__tests__/table-cell-hidden-length.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import { visit } from 'unist-util-visit';
+import type { TableCell } from 'mdast';
+import { countHiddenMarkerLength } from '../table-cell-hidden-length';
+
+function firstTableCellOnLine(md: string, line: number): TableCell {
+  const tree = unified().use(remarkParse).use(remarkGfm).parse(md);
+  let found: TableCell | undefined;
+  visit(tree, 'tableCell', (node) => {
+    if (node.position?.start?.line === line) {
+      found = node as TableCell;
+    }
+  });
+  if (!found) {
+    throw new Error(`no table cell on line ${line}`);
+  }
+  return found;
+}
+
+describe('countHiddenMarkerLength', () => {
+  it('counts only backtick fences for inline code, not GFM escape backslashes before pipes', () => {
+    const md = ['| x |', '|---|', '| `a \\| b` |'].join('\n');
+    const cell = firstTableCellOnLine(md, 3);
+    expect(countHiddenMarkerLength(cell, md)).toBe(0);
+  });
+});

--- a/src/parser/core.ts
+++ b/src/parser/core.ts
@@ -14,14 +14,15 @@ import type {
   ThematicBreak,
   Text,
   Table,
+  Paragraph,
   TableCell,
+  TableRow,
 } from "mdast";
 import {
   addMarkerDecorations as addMarkerDecorationsHelper,
   addScope as addScopeHelper,
   dedupeScopes as dedupeScopesHelper,
   getBoldMarker as getBoldMarkerHelper,
-  getItalicMarker as getItalicMarkerHelper,
   hasValidPosition as hasValidPositionHelper,
   isInCodeBlock as isInCodeBlockHelper,
 } from "./common";
@@ -33,16 +34,20 @@ import {
   scanMentionAndIssueRefs as scanMentionAndIssueRefsHelper,
 } from "./mentions";
 import {
+  buildNativeTableCellPadParts,
+  buildSyntheticTableCellReplacement,
   cellHasMixedFormatting as cellHasMixedFormattingHelper,
-  computeColumnWidths as computeColumnWidthsHelper,
   detectCellStyle as detectCellStyleHelper,
   extractCellPlainText as extractCellPlainTextHelper,
   findPipePositions as findPipePositionsHelper,
   getLineRange as getLineRangeHelper,
+  getTableRowPipeLayout as getTableRowPipeLayoutHelper,
+  measureRenderedWidth as measureRenderedWidthHelper,
   measureTextWidth as measureTextWidthHelper,
   normalizePipePositions as normalizePipePositionsHelper,
   trimLineEnd as trimLineEndHelper,
 } from "./tables";
+import { countHiddenMarkerLength } from "./table-cell-hidden-length";
 import {
   processEmphasis as processEmphasisHelper,
   processHeading as processHeadingHelper,
@@ -1218,14 +1223,6 @@ export class MarkdownParser {
     return getBoldMarkerHelper(text, pos);
   }
 
-  /**
-   * Gets the italic marker type (* or _) from source text.
-   * Optimized to use character code comparisons instead of string allocation.
-   */
-  private getItalicMarker(text: string, pos: number): string | null {
-    return getItalicMarkerHelper(text, pos);
-  }
-
   /** Minimum length required for frontmatter delimiter */
   private static readonly MIN_FRONTMATTER_LENGTH = 3; // '---'
 
@@ -1267,9 +1264,9 @@ export class MarkdownParser {
   }
 
   /**
-   * Returns true if a cell has inline formatting children (strong, emphasis,
-   * delete, inlineCode) that cannot be rendered as whole-cell CSS.
-   * Used to decide whether to show raw syntax vs AST-extracted plain text.
+   * Delegates to `cellHasMixedFormatting` in `tables.ts`: strong, emphasis, delete, or
+   * inlineCode in the cell. Used for raw vs plain-text width, not for the native-cell path
+   * (see `tableCellAstHasRichMarkdown`, which also treats links and images as rich).
    */
   private cellHasMixedFormatting(cell: TableCell): boolean {
     return cellHasMixedFormattingHelper(cell);
@@ -1290,94 +1287,164 @@ export class MarkdownParser {
   }
 
   /**
-   * Measures display width for monospace column alignment of **plain** cell text
-   * (no markdown markers — callers use `extractCellPlainText` / `detectCellStyle` paths).
-   *
-   * CJK wide characters (Unicode ranges U+2E80–U+9FFF, U+F900–U+FAFF,
-   * U+FE30–U+FE4F, U+20000–U+2FA1F) count as 2 columns; all others as 1.
-   *
-   * Adds a small per-CJK-character correction because VS Code's `before`
-   * pseudo-element renders CJK glyphs slightly wider than exactly 2x
-   * ASCII width in most monospace fonts.
-   *
-   * @param plain - Already-unmarked cell display text
-   * @returns Estimated width in monospace columns
+   * True when the cell AST contains any construct that forces the native (non-synthetic)
+   * table cell rendering path: strong, emphasis, delete, inlineCode, link, or image.
+   * Wider than `cellHasMixedFormatting` in `tables.ts` (which only covers strong, emphasis,
+   * delete, and inlineCode for raw vs plain-text width), because links and images need
+   * native layout for correct column math.
    */
-  private measureTextWidth(plain: string): number {
-    return measureTextWidthHelper(plain);
+  private tableCellAstHasRichMarkdown(cell: TableCell): boolean {
+    const walk = (node: Node): boolean => {
+      if (
+        node.type === "strong" ||
+        node.type === "emphasis" ||
+        node.type === "delete" ||
+        node.type === "inlineCode" ||
+        node.type === "link" ||
+        node.type === "image"
+      ) {
+        return true;
+      }
+      const withChildren = node as { children?: Node[] };
+      if (withChildren.children) {
+        return withChildren.children.some(walk);
+      }
+      return false;
+    };
+    return cell.children.some(walk);
+  }
+
+  private cellTextHasDollarMathSyntax(trimmed: string): boolean {
+    if (!trimmed.includes("$")) {
+      return false;
+    }
+    if (/\$\$[\s\S]*?\$\$/.test(trimmed)) {
+      return true;
+    }
+    return /\$[^$\s\n][^$\n]*\$/.test(trimmed);
   }
 
   /**
-   * Finds unescaped pipe positions within a line range.
-   * Counts consecutive preceding backslashes: pipe is escaped only when
-   * the count is odd (e.g. \| is escaped, \\| is not).
+   * Phrasing inside a GFM table cell, unwrapping a single paragraph wrapper when present.
    */
-  private findPipePositions(
-    text: string,
-    lineStart: number,
-    lineEnd: number,
-  ): number[] {
-    return findPipePositionsHelper(text, lineStart, lineEnd);
+  private getTableCellPhrasingChildren(cell: TableCell): Node[] {
+    if (cell.children.length === 1) {
+      const only = cell.children[0]! as Node;
+      if (only.type === "paragraph") {
+        return (only as Paragraph).children;
+      }
+    }
+    return cell.children as Node[];
   }
 
   /**
-   * Augments pipe positions with virtual boundary markers for rows that lack
-   * leading and/or trailing pipe characters. Virtual positions enable cell
-   * boundary detection but should NOT generate tablePipe decorations.
+   * A cell that is only a single inline code span (no other phrasing) can use the same
+   * synthetic padded cell path as plain text so pipes align with `tableCellWidthCh`.
    */
-  private normalizePipePositions(
+  private isSingleInlineCodeOnlyTableCell(cell: TableCell): boolean {
+    const phrasing = this.getTableCellPhrasingChildren(cell);
+    if (phrasing.length !== 1 || phrasing[0]!.type !== "inlineCode") {
+      return false;
+    }
+    const ic = phrasing[0] as InlineCode;
+    if (ic.value.includes("|")) {
+      return false;
+    }
+    return true;
+  }
+
+  private shouldRenderTableCellNative(
+    astCell: TableCell | undefined,
+    trimmedCell: string,
+  ): boolean {
+    if (!astCell) {
+      return false;
+    }
+    if (this.isSingleInlineCodeOnlyTableCell(astCell)) {
+      return false;
+    }
+    return (
+      this.tableCellAstHasRichMarkdown(astCell) ||
+      this.cellTextHasDollarMathSyntax(trimmedCell)
+    );
+  }
+
+  private getTableRowPipeLayout(
+    row: TableRow,
     text: string,
     lineStart: number,
     trimmedLineEnd: number,
-    pipes: number[],
   ): { positions: number[]; isVirtual: boolean[] } {
-    return normalizePipePositionsHelper(text, lineStart, trimmedLineEnd, pipes);
-  }
-
-  /**
-   * Gets the line boundaries (start offset, end offset excluding newline) for a
-   * given character offset within the source text.
-   */
-  private getLineRange(text: string, offset: number): [number, number] {
-    return getLineRangeHelper(text, offset);
-  }
-
-  /**
-   * Trims trailing whitespace from a line range, returning the new end offset.
-   */
-  private trimLineEnd(
-    text: string,
-    lineStart: number,
-    lineEnd: number,
-  ): number {
-    return trimLineEndHelper(text, lineStart, lineEnd);
+    return getTableRowPipeLayoutHelper(row, text, lineStart, trimmedLineEnd);
   }
 
   /**
    * Computes the maximum display width for each column in a table.
    *
-   * Uses pipe positions on each row line to extract cell content, avoiding
-   * remark-gfm cell positions which include pipe characters.
+   * Column count comes from `TableRow` children (remark-gfm). Cell text is taken
+   * from pipe-delimited slices on each line via `getTableRowPipeLayout`, avoiding
+   * raw cell positions that include boundary `|` characters.
    *
    * @param tableNode - The remark Table AST node
    * @param source - The full normalized document text
    * @returns Array of column widths (one per column, minimum 3)
    */
   private computeColumnWidths(tableNode: Table, source: string): number[] {
-    return computeColumnWidthsHelper(tableNode, source);
+    let numCols = 0;
+
+    for (const row of tableNode.children) {
+      if (!row.position || row.position.start.offset === undefined) continue;
+      numCols = Math.max(numCols, row.children.length);
+    }
+
+    const widths: number[] = new Array(numCols).fill(3);
+
+    for (const row of tableNode.children) {
+      if (!row.position || row.position.start.offset === undefined) continue;
+      const [lineStart, lineEnd] = getLineRangeHelper(
+        source,
+        row.position.start.offset,
+      );
+      const trimmed = trimLineEndHelper(source, lineStart, lineEnd);
+      const { positions: pipes } = getTableRowPipeLayoutHelper(
+        row as TableRow,
+        source,
+        lineStart,
+        trimmed,
+      );
+
+      const rowCells = row.children.length;
+      const pipeSlots = Math.min(pipes.length - 1, rowCells);
+      for (let i = 0; i < pipeSlots && i < numCols; i++) {
+        const cellText = source.substring(pipes[i] + 1, pipes[i + 1]).trim();
+        const astCell =
+          i < row.children.length ? (row.children[i] as TableCell) : undefined;
+        const cellStyle = this.detectCellStyle(cellText);
+        const showRaw =
+          !cellStyle && astCell && this.cellHasMixedFormatting(astCell);
+        const useNative = this.shouldRenderTableCellNative(astCell, cellText);
+        let w: number;
+        if (useNative && astCell) {
+          const rawInteriorLen = pipes[i + 1] - pipes[i] - 1;
+          const hiddenLen = countHiddenMarkerLength(astCell, source);
+          w = Math.max(0, rawInteriorLen - hiddenLen);
+        } else {
+          const displayTextForWidth =
+            astCell && !showRaw
+              ? this.extractCellPlainText(astCell)
+              : cellText;
+          w = measureTextWidthHelper(displayTextForWidth);
+        }
+        if (w > widths[i]) widths[i] = w;
+      }
+    }
+
+    return widths;
   }
 
   /**
-   * Processes a GFM table node and emits decorations for pipes, cells, and the separator row.
-   *
-   * Produces:
-   * - `tablePipe` decorations for `|` in header and data rows (replaced with `│`)
-   * - `tableSeparatorPipe` decorations for `|` in the separator row (replaced with `├`, `┼`, or `┤`)
-   * - `tableSeparatorDash` decorations for dash segments in the separator row (replaced with `─` repeats)
-   * - `tableCell` decorations for cell content (padded to uniform column width)
-   *
-   * Also adds a scope for the entire table so the visibility model can reveal the
-   * whole block when the cursor is inside it.
+   * GFM table: pipe, separator, dash, padded `tableCell`, and `tableCellNativePad` for rich cells.
+   * Adds a table scope for whole-block raw reveal when the cursor is inside.
    */
   private processTable(
     node: Table,
@@ -1411,59 +1478,74 @@ export class MarkdownParser {
       }
 
       const rowStartOffset = row.position.start.offset;
-      const [lineStart, lineEnd] = this.getLineRange(text, rowStartOffset);
-      const trimmedLineEnd = this.trimLineEnd(text, lineStart, lineEnd);
-      const rawPipes = this.findPipePositions(text, lineStart, trimmedLineEnd);
-      const { positions: pipes, isVirtual } = this.normalizePipePositions(
-        text, lineStart, trimmedLineEnd, rawPipes,
+      const [lineStart, lineEnd] = getLineRangeHelper(text, rowStartOffset);
+      const trimmedLineEnd = trimLineEndHelper(text, lineStart, lineEnd);
+      const { positions: pipes, isVirtual } = getTableRowPipeLayoutHelper(
+        row as TableRow,
+        text,
+        lineStart,
+        trimmedLineEnd,
       );
 
-      // Only decorate real (non-virtual) pipes
-      for (let pIdx = 0; pIdx < pipes.length; pIdx++) {
-        if (!isVirtual[pIdx]) {
-          decorations.push({
-            startPos: pipes[pIdx],
-            endPos: pipes[pIdx] + 1,
-            type: "tablePipe",
-            replacement: "\u2502", // │
-          });
-        }
-      }
+      const nativeTrailBeforePipe = new Map<number, string>();
 
-      // Derive cells from pipe positions (avoids remark cell positions which include pipes)
-      for (let i = 0; i < pipes.length - 1; i++) {
+      const rowCellCount = row.children.length;
+      const cellSlots = Math.min(pipes.length - 1, rowCellCount);
+      for (let i = 0; i < cellSlots; i++) {
         const cellRangeStart = pipes[i] + 1;
         const cellRangeEnd = pipes[i + 1];
         if (cellRangeStart >= cellRangeEnd) continue;
 
         const rawContent = text.substring(cellRangeStart, cellRangeEnd);
         const trimmedContent = rawContent.trim();
-        const cellStyle = this.detectCellStyle(trimmedContent);
+        const astCell =
+          i < row.children.length ? (row.children[i] as TableCell) : undefined;
+        const detectedCellStyle = this.detectCellStyle(trimmedContent);
+        const fromWholeCellInlineCode =
+          astCell !== undefined && this.isSingleInlineCodeOnlyTableCell(astCell);
+        const cellStyle = fromWholeCellInlineCode
+          ? { ...detectedCellStyle, useTextPreformatColors: true as const }
+          : detectedCellStyle;
         const colWidth = i < colWidths.length ? colWidths[i] : 3;
-
-        // Whole-cell styled: extract clean text via AST + apply CSS
-        // Mixed formatting: show raw syntax (VS Code can't partially style)
-        // Plain / escaped: use AST extraction (handles \| → |, \\ → \)
-        const astCell = i < row.children.length ? row.children[i] as TableCell : undefined;
-        const showRaw = !cellStyle && astCell && this.cellHasMixedFormatting(astCell);
-        const displayContent = (astCell && !showRaw)
-          ? this.extractCellPlainText(astCell)
-          : trimmedContent;
-        const displayWidth = this.measureTextWidth(displayContent);
-        const totalPad = Math.max(0, colWidth - displayWidth);
         const align = i < colAligns.length ? colAligns[i] : null;
 
-        let replacement: string;
-        if (align === "right") {
-          replacement = "\u00A0".repeat(totalPad + 1) + displayContent + "\u00A0";
-        } else if (align === "center") {
-          const padLeft = Math.floor(totalPad / 2);
-          const padRight = totalPad - padLeft;
-          replacement = "\u00A0".repeat(padLeft + 1) + displayContent + "\u00A0".repeat(padRight + 1);
-        } else {
-          // left or null (default)
-          replacement = "\u00A0" + displayContent + "\u00A0".repeat(totalPad + 1);
+        const showRaw =
+          !cellStyle && !!astCell && this.cellHasMixedFormatting(astCell);
+        const useNative = this.shouldRenderTableCellNative(
+          astCell,
+          trimmedContent,
+        );
+        if (useNative) {
+          const hiddenLen = astCell
+            ? countHiddenMarkerLength(astCell, text)
+            : 0;
+          const displayWidth = Math.max(0, rawContent.length - hiddenLen);
+          const totalPad = Math.max(0, colWidth - displayWidth);
+          const { leadingNbsp, trailingNbsp } = buildNativeTableCellPadParts(
+            align,
+            totalPad,
+          );
+          nativeTrailBeforePipe.set(pipes[i + 1], trailingNbsp);
+          decorations.push({
+            startPos: cellRangeStart,
+            endPos: cellRangeEnd,
+            type: "tableCellNativePad",
+            replacement: leadingNbsp,
+          });
+          continue;
         }
+
+        const displayContent =
+          astCell && !showRaw
+            ? this.extractCellPlainText(astCell)
+            : trimmedContent;
+        const renderedWidth = measureRenderedWidthHelper(displayContent);
+        const totalPad = Math.max(0, colWidth - renderedWidth);
+        const replacement = buildSyntheticTableCellReplacement(
+          align,
+          totalPad,
+          displayContent,
+        );
 
         decorations.push({
           startPos: cellRangeStart,
@@ -1471,11 +1553,23 @@ export class MarkdownParser {
           type: "tableCell",
           replacement,
           cellStyle,
+          tableCellWidthCh: colWidth + 2,
         });
       }
 
-      // After the header row (index 0), process the separator row.
-      // remark-gfm does NOT include the separator row as a child node.
+      for (let pIdx = 0; pIdx < pipes.length; pIdx++) {
+        if (!isVirtual[pIdx]) {
+          const prefix = nativeTrailBeforePipe.get(pipes[pIdx]) ?? "";
+          decorations.push({
+            startPos: pipes[pIdx],
+            endPos: pipes[pIdx] + 1,
+            type: "tablePipe",
+            replacement: "\u2502",
+            ...(prefix !== "" ? { replacementPrefix: prefix } : {}),
+          });
+        }
+      }
+
       if (rowIdx === 0) {
         const headerEndOffset = row.position.end.offset;
 
@@ -1495,22 +1589,23 @@ export class MarkdownParser {
           if (sepLineEnd === -1) sepLineEnd = tableEnd;
         }
 
-        const trimmedSepEnd = this.trimLineEnd(text, sepLineStart, sepLineEnd);
-        const rawSepPipes = this.findPipePositions(text, sepLineStart, trimmedSepEnd);
-        const { positions: sepPipes, isVirtual: sepIsVirtual } = this.normalizePipePositions(
-          text, sepLineStart, trimmedSepEnd, rawSepPipes,
-        );
+        const trimmedSepEnd = trimLineEndHelper(text, sepLineStart, sepLineEnd);
+        const rawSepPipes = findPipePositionsHelper(text, sepLineStart, trimmedSepEnd);
+        const { positions: sepPipes, isVirtual: sepIsVirtual } =
+          normalizePipePositionsHelper(
+            text,
+            sepLineStart,
+            trimmedSepEnd,
+            rawSepPipes,
+          );
 
-        // Use │ for separator pipes (same as data rows) and ASCII - for
-        // dashes. Box-drawing ─ (U+2500) renders wider than monospace chars
-        // in many editor fonts, causing cumulative misalignment.
         for (let pIdx = 0; pIdx < sepPipes.length; pIdx++) {
           if (!sepIsVirtual[pIdx]) {
             decorations.push({
               startPos: sepPipes[pIdx],
               endPos: sepPipes[pIdx] + 1,
               type: "tableSeparatorPipe",
-              replacement: "\u2502", // │ (same as regular pipe)
+              replacement: "\u2502",
             });
           }
         }

--- a/src/parser/core.ts
+++ b/src/parser/core.ts
@@ -300,14 +300,23 @@ export class MarkdownParser {
               );
               break;
 
-            case "inlineCode":
-              this.processInlineCode(
-                node as InlineCode,
-                text,
-                decorations,
-                scopes,
-              );
+            case "inlineCode": {
+              const inlineCodeNode = node as InlineCode;
+              if (
+                !this.isInlineCodeHandledBySyntheticTableCell(
+                  inlineCodeNode,
+                  currentAncestors,
+                )
+              ) {
+                this.processInlineCode(
+                  inlineCodeNode,
+                  text,
+                  decorations,
+                  scopes,
+                );
+              }
               break;
+            }
 
             case "code":
               this.processCodeBlock(
@@ -1341,6 +1350,25 @@ export class MarkdownParser {
    * A cell that is only a single inline code span (no other phrasing) can use the same
    * synthetic padded cell path as plain text so pipes align with `tableCellWidthCh`.
    */
+  /**
+   * Whole-cell inline code uses synthetic `tableCell` rendering; skip per-span
+   * `code` decorations so `filterDecorationsInCodeBlocks` does not drop the cell.
+   */
+  private isInlineCodeHandledBySyntheticTableCell(
+    node: InlineCode,
+    ancestors: Node[],
+  ): boolean {
+    const tableCell = ancestors.find((a) => a.type === "tableCell");
+    if (!tableCell) {
+      return false;
+    }
+    if (!this.isSingleInlineCodeOnlyTableCell(tableCell as TableCell)) {
+      return false;
+    }
+    const phrasing = this.getTableCellPhrasingChildren(tableCell as TableCell);
+    return phrasing.length === 1 && phrasing[0] === node;
+  }
+
   private isSingleInlineCodeOnlyTableCell(cell: TableCell): boolean {
     const phrasing = this.getTableCellPhrasingChildren(cell);
     if (phrasing.length !== 1 || phrasing[0]!.type !== "inlineCode") {
@@ -1356,6 +1384,9 @@ export class MarkdownParser {
   private shouldRenderTableCellNative(
     astCell: TableCell | undefined,
     trimmedCell: string,
+    detectedCellStyle:
+      | { fontWeight?: string; fontStyle?: string; textDecoration?: string }
+      | undefined,
   ): boolean {
     if (!astCell) {
       return false;
@@ -1363,9 +1394,28 @@ export class MarkdownParser {
     if (this.isSingleInlineCodeOnlyTableCell(astCell)) {
       return false;
     }
+    // Whole-cell marker styling without phrasing nodes needs synthetic contentText.
+    if (detectedCellStyle && !this.tableCellAstHasRichMarkdown(astCell)) {
+      return false;
+    }
     return (
       this.tableCellAstHasRichMarkdown(astCell) ||
-      this.cellTextHasDollarMathSyntax(trimmedCell)
+      this.cellTextHasDollarMathSyntax(trimmedCell) ||
+      !this.cellHasMixedFormatting(astCell)
+    );
+  }
+
+  /** Plain text cells: native layout with visible source for correct click positions. */
+  private isPlainNativeTableCell(
+    astCell: TableCell | undefined,
+    detectedCellStyle:
+      | { fontWeight?: string; fontStyle?: string; textDecoration?: string }
+      | undefined,
+  ): boolean {
+    return (
+      !!astCell &&
+      !detectedCellStyle &&
+      !this.cellHasMixedFormatting(astCell)
     );
   }
 
@@ -1422,9 +1472,20 @@ export class MarkdownParser {
         const cellStyle = this.detectCellStyle(cellText);
         const showRaw =
           !cellStyle && astCell && this.cellHasMixedFormatting(astCell);
-        const useNative = this.shouldRenderTableCellNative(astCell, cellText);
+        const useNative = this.shouldRenderTableCellNative(
+          astCell,
+          cellText,
+          cellStyle,
+        );
+        const isPlainNative = this.isPlainNativeTableCell(astCell, cellStyle);
         let w: number;
-        if (useNative && astCell) {
+        if (useNative && astCell && isPlainNative) {
+          const displayTextForWidth =
+            astCell && !showRaw
+              ? this.extractCellPlainText(astCell)
+              : cellText;
+          w = measureTextWidthHelper(displayTextForWidth);
+        } else if (useNative && astCell) {
           const rawInteriorLen = pipes[i + 1] - pipes[i] - 1;
           const hiddenLen = countHiddenMarkerLength(astCell, source);
           w = Math.max(0, rawInteriorLen - hiddenLen);
@@ -1514,24 +1575,75 @@ export class MarkdownParser {
         const useNative = this.shouldRenderTableCellNative(
           astCell,
           trimmedContent,
+          cellStyle,
         );
         if (useNative) {
-          const hiddenLen = astCell
-            ? countHiddenMarkerLength(astCell, text)
-            : 0;
-          const displayWidth = Math.max(0, rawContent.length - hiddenLen);
+          const isPlainNative = this.isPlainNativeTableCell(astCell, cellStyle);
+          const plainDisplayContent =
+            astCell && !showRaw
+              ? this.extractCellPlainText(astCell)
+              : trimmedContent;
+          let displayWidth: number;
+          if (isPlainNative) {
+            displayWidth = measureRenderedWidthHelper(plainDisplayContent);
+          } else {
+            const hiddenLen = astCell
+              ? countHiddenMarkerLength(astCell, text)
+              : 0;
+            displayWidth = Math.max(0, rawContent.length - hiddenLen);
+          }
           const totalPad = Math.max(0, colWidth - displayWidth);
           const { leadingNbsp, trailingNbsp } = buildNativeTableCellPadParts(
             align,
             totalPad,
           );
           nativeTrailBeforePipe.set(pipes[i + 1], trailingNbsp);
-          decorations.push({
-            startPos: cellRangeStart,
-            endPos: cellRangeEnd,
-            type: "tableCellNativePad",
-            replacement: leadingNbsp,
-          });
+
+          if (isPlainNative) {
+            const leadingPadLen =
+              rawContent.length - rawContent.trimStart().length;
+            const trailingPadLen =
+              rawContent.length - rawContent.trimEnd().length;
+            const contentStart = cellRangeStart + leadingPadLen;
+            const contentEnd = cellRangeEnd - trailingPadLen;
+
+            if (leadingPadLen > 0) {
+              decorations.push({
+                startPos: cellRangeStart,
+                endPos: contentStart,
+                type: "hide",
+              });
+            }
+            if (contentStart < contentEnd) {
+              decorations.push({
+                startPos: contentStart,
+                endPos: contentEnd,
+                type: "tableCellNativePad",
+                replacement: leadingNbsp,
+              });
+            } else {
+              decorations.push({
+                startPos: cellRangeStart,
+                endPos: cellRangeEnd,
+                type: "tableCellNativePad",
+                replacement: leadingNbsp,
+              });
+            }
+            if (trailingPadLen > 0) {
+              decorations.push({
+                startPos: contentEnd,
+                endPos: cellRangeEnd,
+                type: "hide",
+              });
+            }
+          } else {
+            decorations.push({
+              startPos: cellRangeStart,
+              endPos: cellRangeEnd,
+              type: "tableCellNativePad",
+              replacement: leadingNbsp,
+            });
+          }
           continue;
         }
 
@@ -1547,14 +1659,66 @@ export class MarkdownParser {
           displayContent,
         );
 
+        const leadingPadLen =
+          rawContent.length - rawContent.trimStart().length;
+        const trailingPadLen =
+          rawContent.length - rawContent.trimEnd().length;
+        let contentStart = cellRangeStart + leadingPadLen;
+        let contentEnd = cellRangeEnd - trailingPadLen;
+
+        if (astCell !== undefined && this.isSingleInlineCodeOnlyTableCell(astCell)) {
+          const ic = this.getTableCellPhrasingChildren(astCell)[0] as InlineCode;
+          if (this.hasValidPosition(ic)) {
+            const icStart = ic.position!.start.offset!;
+            const icEnd = ic.position!.end.offset!;
+            let markerLen = 0;
+            while (icStart + markerLen < icEnd && text[icStart + markerLen] === "`") {
+              markerLen++;
+            }
+            if (markerLen > 0) {
+              contentStart = icStart + markerLen;
+              contentEnd = icEnd - markerLen;
+            }
+          }
+        }
+
+        // Synthetic cells use display:none; click position maps across the
+        // decoration range. Scope tableCell to trimmed source and hide GFM
+        // padding spaces so clicks land on visible characters.
+        if (contentStart >= contentEnd) {
+          decorations.push({
+            startPos: cellRangeStart,
+            endPos: cellRangeEnd,
+            type: "tableCell",
+            replacement,
+            cellStyle,
+            tableCellWidthCh: colWidth + 2,
+          });
+          continue;
+        }
+
+        if (leadingPadLen > 0) {
+          decorations.push({
+            startPos: cellRangeStart,
+            endPos: contentStart,
+            type: "hide",
+          });
+        }
         decorations.push({
-          startPos: cellRangeStart,
-          endPos: cellRangeEnd,
+          startPos: contentStart,
+          endPos: contentEnd,
           type: "tableCell",
           replacement,
           cellStyle,
           tableCellWidthCh: colWidth + 2,
         });
+        if (trailingPadLen > 0) {
+          decorations.push({
+            startPos: contentEnd,
+            endPos: cellRangeEnd,
+            type: "hide",
+          });
+        }
       }
 
       for (let pIdx = 0; pIdx < pipes.length; pIdx++) {

--- a/src/parser/table-cell-hidden-length.ts
+++ b/src/parser/table-cell-hidden-length.ts
@@ -2,7 +2,6 @@ import type {
   Delete,
   Emphasis,
   Image,
-  InlineCode,
   Link,
   Node,
   Strong,
@@ -154,17 +153,10 @@ export function countHiddenMarkerLength(cell: TableCell, source: string): number
         return;
       }
       case 'inlineCode': {
-        const ic = node as InlineCode;
-        const start = ic.position?.start.offset;
-        const end = ic.position?.end.offset;
-        if (start === undefined || end === undefined) {
-          return;
-        }
-        const span = end - start;
-        const innerLen = ic.value.length;
-        if (span > innerLen) {
-          total += span - innerLen;
-        }
+        // Backtick fences use `transparent` (see `TransparentDecorationType`), not
+        // `display: none`, so they still consume column width. Do not subtract them here,
+        // and do not use `span - innerLen` (that also removes escape `\` bytes that stay
+        // visible in the source).
         return;
       }
       case 'link': {

--- a/src/parser/table-cell-hidden-length.ts
+++ b/src/parser/table-cell-hidden-length.ts
@@ -1,0 +1,218 @@
+import type {
+  Delete,
+  Emphasis,
+  Image,
+  InlineCode,
+  Link,
+  Node,
+  Strong,
+  TableCell,
+  Text,
+} from 'mdast';
+import { getItalicMarker, hasValidPosition } from './common';
+
+function strongDelimiterRunLength(source: string, strongStart: number): number {
+  const marker = source[strongStart];
+  if (marker === undefined) {
+    return 0;
+  }
+  let len = 0;
+  while (source[strongStart + len] === marker) {
+    len++;
+  }
+  return len;
+}
+
+/**
+ * Characters hidden by image decorations (markers and URL), excluding alt text.
+ * Used with table native-column width math; must stay aligned with image decoration ranges.
+ */
+export function countImageSyntaxHiddenLength(node: Image, source: string): number {
+  if (!hasValidPosition(node)) {
+    return 0;
+  }
+  const start = node.position!.start.offset!;
+  const end = node.position!.end.offset!;
+  const exclamationStart = source.indexOf('![', start);
+  if (exclamationStart === -1 || exclamationStart > start) {
+    return 0;
+  }
+  let n = 2;
+  const altStart = exclamationStart + 2;
+  const bracketEnd = source.indexOf(']', altStart);
+  if (bracketEnd === -1) {
+    return n;
+  }
+  n += 1;
+  const parenStart = source.indexOf('(', bracketEnd);
+  if (parenStart === -1) {
+    return n;
+  }
+  const between = source.substring(bracketEnd + 1, parenStart);
+  const hasOnlyWhitespaceBetween =
+    between.length > 0 && between.trim().length === 0;
+  if (parenStart !== bracketEnd + 1 && !hasOnlyWhitespaceBetween) {
+    return n;
+  }
+  if (hasOnlyWhitespaceBetween) {
+    n += parenStart - (bracketEnd + 1);
+  }
+  n += 1;
+  const parenEnd = source.indexOf(')', parenStart + 1);
+  if (parenEnd === -1 || parenEnd > end) {
+    return n;
+  }
+  const urlStart = parenStart + 1;
+  if (urlStart < parenEnd) {
+    n += parenEnd - urlStart;
+  }
+  n += 1;
+  return n;
+}
+
+/**
+ * Counts source characters inside a table cell that decorations hide, for native-cell
+ * column width math. Keep in sync with inline hide rules in the main parser.
+ */
+export function countHiddenMarkerLength(cell: TableCell, source: string): number {
+  let total = 0;
+  const walk = (node: Node, ancestors: Node[]): void => {
+    switch (node.type) {
+      case 'strong': {
+        const start = node.position?.start.offset;
+        if (start !== undefined && source[start] !== undefined) {
+          const run = strongDelimiterRunLength(source, start);
+          if (run > 0) {
+            total += run * 2;
+          }
+        }
+        const strongNode = node as Strong;
+        ancestors.push(node);
+        strongNode.children.forEach((ch) => walk(ch, ancestors));
+        ancestors.pop();
+        return;
+      }
+      case 'emphasis': {
+        const em = node as Emphasis;
+        const start = em.position?.start.offset;
+        const end = em.position?.end.offset;
+        if (start !== undefined && end !== undefined) {
+          const marker = getItalicMarker(source, start);
+          if (marker) {
+            const markerLength = marker.length;
+            const parentStrong = ancestors.find((a) => a.type === 'strong');
+            if (
+              parentStrong?.position?.start?.offset !== undefined &&
+              parentStrong.position.end?.offset !== undefined
+            ) {
+              const strongStart = parentStrong.position.start.offset;
+              const strongEnd = parentStrong.position.end.offset;
+              const strongRun = strongDelimiterRunLength(
+                source,
+                strongStart,
+              );
+              if (
+                strongRun > 0 &&
+                start === strongStart + strongRun &&
+                end === strongEnd - strongRun
+              ) {
+                ancestors.push(node);
+                em.children.forEach((ch) => walk(ch, ancestors));
+                ancestors.pop();
+                return;
+              }
+            }
+            total += markerLength * 2;
+          }
+        }
+        ancestors.push(node);
+        em.children.forEach((ch) => walk(ch, ancestors));
+        ancestors.pop();
+        return;
+      }
+      case 'delete': {
+        const del = node as Delete;
+        const start = del.position?.start.offset;
+        const end = del.position?.end.offset;
+        if (
+          start === undefined ||
+          end === undefined ||
+          start + 1 >= source.length ||
+          source[start] !== '~' ||
+          source[start + 1] !== '~' ||
+          end < 2 ||
+          source[end - 2] !== '~' ||
+          source[end - 1] !== '~'
+        ) {
+          del.children.forEach((ch) => walk(ch, ancestors));
+          return;
+        }
+        total += 4;
+        ancestors.push(node);
+        del.children.forEach((ch) => walk(ch, ancestors));
+        ancestors.pop();
+        return;
+      }
+      case 'inlineCode': {
+        const ic = node as InlineCode;
+        const start = ic.position?.start.offset;
+        const end = ic.position?.end.offset;
+        if (start === undefined || end === undefined) {
+          return;
+        }
+        const span = end - start;
+        const innerLen = ic.value.length;
+        if (span > innerLen) {
+          total += span - innerLen;
+        }
+        return;
+      }
+      case 'link': {
+        const start = node.position?.start.offset;
+        const end = node.position?.end.offset;
+        if (start === undefined || end === undefined) return;
+        if (source[start] === '<' && source[end - 1] === '>') {
+          total += 2;
+          return;
+        }
+        const linkNode = node as Link;
+        const firstChild = linkNode.children?.[0];
+        const linkText =
+          firstChild && firstChild.type === 'text'
+            ? (firstChild as Text).value
+            : '';
+        const url = linkNode.url || '';
+        const urlNoMail = url.replace(/^mailto:/, '');
+        if (linkText === url || linkText === urlNoMail) {
+          return;
+        }
+        const bracketStart = source.indexOf('[', start);
+        const bracketEnd = source.indexOf(']', bracketStart);
+        if (bracketStart === -1 || bracketEnd === -1 || bracketEnd >= end)
+          return;
+        total += 2;
+        const parenStart = bracketEnd + 1;
+        if (source[parenStart] === '(') {
+          const parenEnd = source.indexOf(')', parenStart + 1);
+          if (parenEnd !== -1 && parenEnd < end) {
+            total += parenEnd - parenStart + 1;
+          }
+        }
+        (linkNode.children || []).forEach((ch) => walk(ch, ancestors));
+        return;
+      }
+      case 'image': {
+        total += countImageSyntaxHiddenLength(node as Image, source);
+        return;
+      }
+      default: {
+        const asParent = node as { children?: Node[] };
+        if (asParent.children) {
+          asParent.children.forEach((ch) => walk(ch, ancestors));
+        }
+      }
+    }
+  };
+  cell.children.forEach((ch) => walk(ch, []));
+  return total;
+}

--- a/src/parser/tables.ts
+++ b/src/parser/tables.ts
@@ -4,12 +4,12 @@ import type {
   InlineCode,
   Node,
   Strong,
-  Table,
   TableCell,
+  TableRow,
   Text,
 } from 'mdast';
 import type { ScopeRange } from './types';
-import { addScope } from './common';
+import { addScope, hasValidPosition } from './common';
 
 export function extractCellPlainText(cell: TableCell): string {
   const walk = (node: Node): string => {
@@ -34,6 +34,11 @@ export function extractCellPlainText(cell: TableCell): string {
   return cell.children.map(walk).join('');
 }
 
+/**
+ * True when the cell AST contains strong, emphasis, delete, or inlineCode.
+ * Used to choose raw cell text vs `extractCellPlainText` for display width.
+ * This does **not** treat links or images as mixed (see `MarkdownParser` rich-native check).
+ */
 export function cellHasMixedFormatting(cell: TableCell): boolean {
   return cell.children.some((child) =>
     child.type === 'strong' || child.type === 'emphasis' ||
@@ -71,24 +76,69 @@ export function detectCellStyle(
   return undefined;
 }
 
+export function isWideCodePoint(code: number): boolean {
+  return (
+    (code >= 0x1100 && code <= 0x115f) ||
+    (code >= 0x2e80 && code <= 0x303e) ||
+    (code >= 0x3041 && code <= 0x33ff) ||
+    (code >= 0x3400 && code <= 0x4dbf) ||
+    (code >= 0x4e00 && code <= 0x9fff) ||
+    (code >= 0xa000 && code <= 0xa4cf) ||
+    (code >= 0xac00 && code <= 0xd7a3) ||
+    (code >= 0xf900 && code <= 0xfaff) ||
+    (code >= 0xfe30 && code <= 0xfe4f) ||
+    (code >= 0xff00 && code <= 0xff60) ||
+    (code >= 0xffe0 && code <= 0xffe6) ||
+    (code >= 0x1f000 && code <= 0x1faff) ||
+    (code >= 0x2600 && code <= 0x27bf) ||
+    (code >= 0x20000 && code <= 0x2fa1f) ||
+    (code >= 0x1f1e6 && code <= 0x1f1ff)
+  );
+}
+
+export function isZeroWidthCodePoint(code: number): boolean {
+  return (
+    code === 0x200d ||
+    code === 0x200c ||
+    code === 0xfeff ||
+    (code >= 0xfe00 && code <= 0xfe0f) ||
+    (code >= 0xe0100 && code <= 0xe01ef) ||
+    (code >= 0x0300 && code <= 0x036f)
+  );
+}
+
+/**
+ * Display width for **column budgeting** (max column width), with wide-glyph overshoot.
+ */
 export function measureTextWidth(plain: string): number {
   let width = 0;
-  let cjkCount = 0;
+  let wideOvershoot = 0;
   for (const char of plain) {
     const code = char.codePointAt(0)!;
-    if (
-      (code >= 0x2e80 && code <= 0x9fff) ||
-      (code >= 0xf900 && code <= 0xfaff) ||
-      (code >= 0xfe30 && code <= 0xfe4f) ||
-      (code >= 0x20000 && code <= 0x2fa1f)
-    ) {
+    if (isWideCodePoint(code)) {
       width += 2;
-      cjkCount++;
-    } else {
+      wideOvershoot += 0.5;
+    } else if (!isZeroWidthCodePoint(code)) {
       width += 1;
     }
   }
-  return width + Math.ceil(cjkCount * 0.25);
+  return width + Math.ceil(wideOvershoot);
+}
+
+/**
+ * Literal monospace column count without wide overshoot (for NBSP padding).
+ */
+export function measureRenderedWidth(plain: string): number {
+  let width = 0;
+  for (const char of plain) {
+    const code = char.codePointAt(0)!;
+    if (isWideCodePoint(code)) {
+      width += 2;
+    } else if (!isZeroWidthCodePoint(code)) {
+      width += 1;
+    }
+  }
+  return width;
 }
 
 export function findPipePositions(
@@ -145,6 +195,81 @@ export function normalizePipePositions(
   return { positions, isVirtual };
 }
 
+/**
+ * Pipe column boundaries from remark-gfm `TableCell` positions (cell starts
+ * act as interior pipe indices, plus optional leading and trailing `|`).
+ */
+export function getAstTablePipeOffsetsFromRow(
+  row: TableRow,
+  text: string,
+): number[] | null {
+  const cells = row.children;
+  if (cells.length === 0) {
+    return null;
+  }
+  for (const c of cells) {
+    if (!hasValidPosition(c as Node)) {
+      return null;
+    }
+  }
+
+  const pipes: number[] = [];
+  for (let i = 0; i < cells.length; i++) {
+    const start = (cells[i] as TableCell).position!.start.offset!;
+    if (i === 0) {
+      if (text[start] === '|') {
+        pipes.push(start);
+      }
+    } else {
+      pipes.push(start);
+    }
+  }
+
+  const lastCell = cells[cells.length - 1] as TableCell;
+  const endOff = lastCell.position!.end.offset!;
+  const trailingIdx = endOff - 1;
+  if (
+    trailingIdx >= 0 &&
+    text[trailingIdx] === '|' &&
+    (pipes.length === 0 || pipes[pipes.length - 1] !== trailingIdx)
+  ) {
+    pipes.push(trailingIdx);
+  }
+
+  for (let k = 1; k < pipes.length; k++) {
+    if (pipes[k] <= pipes[k - 1]) {
+      return null;
+    }
+  }
+
+  return pipes;
+}
+
+export function getTableRowPipeLayout(
+  row: TableRow,
+  text: string,
+  lineStart: number,
+  trimmedLineEnd: number,
+): { positions: number[]; isVirtual: boolean[] } {
+  const astPipes = getAstTablePipeOffsetsFromRow(row, text);
+  let rawPipes: number[];
+  if (
+    astPipes !== null &&
+    astPipes.length > 0 &&
+    astPipes.every((p) => p >= lineStart && p < trimmedLineEnd)
+  ) {
+    rawPipes = astPipes;
+  } else {
+    rawPipes = findPipePositions(text, lineStart, trimmedLineEnd);
+  }
+  return normalizePipePositions(
+    text,
+    lineStart,
+    trimmedLineEnd,
+    rawPipes,
+  );
+}
+
 export function getLineRange(text: string, offset: number): [number, number] {
   const lineStart = offset === 0 ? 0 : text.lastIndexOf('\n', offset - 1) + 1;
   let lineEnd = text.indexOf('\n', offset);
@@ -163,42 +288,48 @@ export function trimLineEnd(text: string, lineStart: number, lineEnd: number): n
   return end;
 }
 
-export function computeColumnWidths(tableNode: Table, source: string): number[] {
-  let numCols = 0;
+const TABLE_CELL_NBSP = '\u00A0';
 
-  for (const row of tableNode.children) {
-    if (!row.position || row.position.start.offset === undefined) continue;
-    const [lineStart, lineEnd] = getLineRange(source, row.position.start.offset);
-    const trimmed = trimLineEnd(source, lineStart, lineEnd);
-    const rawPipes = findPipePositions(source, lineStart, trimmed);
-    const { positions: pipes } = normalizePipePositions(source, lineStart, trimmed, rawPipes);
-    const cellCount = Math.max(0, pipes.length - 1);
-    if (cellCount > numCols) numCols = cellCount;
+/** GFM column alignment from `Table.align` entries. */
+export type GfmColumnAlign = 'left' | 'right' | 'center' | null | undefined;
+
+/**
+ * NBSP repeat counts for leading and trailing cell padding (includes gutter next to pipes).
+ * Shared by native pad splits and synthetic `tableCell` replacement strings.
+ */
+export function leadingTrailingNbspRepeatCounts(
+  align: GfmColumnAlign,
+  totalPad: number,
+): { leading: number; trailing: number } {
+  if (align === 'right') {
+    return { leading: totalPad + 1, trailing: 1 };
   }
-
-  const widths: number[] = new Array(numCols).fill(3);
-
-  for (const row of tableNode.children) {
-    if (!row.position || row.position.start.offset === undefined) continue;
-    const [lineStart, lineEnd] = getLineRange(source, row.position.start.offset);
-    const trimmed = trimLineEnd(source, lineStart, lineEnd);
-    const rawPipes = findPipePositions(source, lineStart, trimmed);
-    const { positions: pipes } = normalizePipePositions(source, lineStart, trimmed, rawPipes);
-
-    for (let i = 0; i < pipes.length - 1 && i < numCols; i++) {
-      const cellText = source.substring(pipes[i] + 1, pipes[i + 1]).trim();
-      const astCell = i < row.children.length ? row.children[i] as TableCell : undefined;
-      const cellStyle = detectCellStyle(cellText);
-      const showRaw = !cellStyle && astCell && cellHasMixedFormatting(astCell);
-      const displayText = (astCell && !showRaw)
-        ? extractCellPlainText(astCell)
-        : cellText;
-      const width = measureTextWidth(displayText);
-      if (width > widths[i]) widths[i] = width;
-    }
+  if (align === 'center') {
+    const padLeft = Math.floor(totalPad / 2);
+    const padRight = totalPad - padLeft;
+    return { leading: padLeft + 1, trailing: padRight + 1 };
   }
+  return { leading: 1, trailing: totalPad + 1 };
+}
 
-  return widths;
+export function buildSyntheticTableCellReplacement(
+  align: GfmColumnAlign,
+  totalPad: number,
+  displayContent: string,
+): string {
+  const { leading, trailing } = leadingTrailingNbspRepeatCounts(align, totalPad);
+  return TABLE_CELL_NBSP.repeat(leading) + displayContent + TABLE_CELL_NBSP.repeat(trailing);
+}
+
+export function buildNativeTableCellPadParts(
+  align: GfmColumnAlign,
+  totalPad: number,
+): { leadingNbsp: string; trailingNbsp: string } {
+  const { leading, trailing } = leadingTrailingNbspRepeatCounts(align, totalPad);
+  return {
+    leadingNbsp: TABLE_CELL_NBSP.repeat(leading),
+    trailingNbsp: TABLE_CELL_NBSP.repeat(trailing),
+  };
 }
 
 export function addTableScope(scopes: ScopeRange[], tableStart: number, tableEnd: number): void {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -6,11 +6,20 @@ export interface DecorationRange {
   level?: number;
   emoji?: string;
   replacement?: string;
+  /** `tablePipe` only: NBSP prefix before the pipe glyph (native cell trailing pad). */
+  replacementPrefix?: string;
   cellStyle?: {
     fontWeight?: string;
     fontStyle?: string;
     textDecoration?: string;
+    /**
+     * When true, tableCell `before` uses `textPreformat.*` so whole-cell inline code
+     * matches normal markdown code styling instead of `editor.foreground`.
+     */
+    useTextPreformatColors?: boolean;
   };
+  /** `tableCell` only: `before` width in `ch` for monospace column alignment. */
+  tableCellWidthCh?: number;
   slug?: string;
   issueNumber?: number;
   ownerRepo?: string;
@@ -79,5 +88,6 @@ export type DecorationType =
   | "tableSeparatorPipe"
   | "tableSeparatorDash"
   | "tableCell"
+  | "tableCellNativePad"
   | "mention"
   | "issueReference";


### PR DESCRIPTION
## Summary

Improves **GFM table** rendering: parse and decorate inline markdown inside table cells more reliably, and adjust **visibility** so working in a table shows consistent raw vs rendered behavior.

## How to verify

Open a markdown file with pipe tables; confirm cell styling and that moving the cursor/selection through the table toggles raw markdown as expected.

## Screenshots

<img width="496" height="1308" alt="image" src="https://github.com/user-attachments/assets/fa48554f-1607-45ca-97aa-8d96e58e8702" />
