### PR TITLE
feat(links): optional chain icon after hyperlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,17 +112,17 @@
           "description": "Opacity for code block language identifiers",
           "markdownDescription": "Opacity of code block language identifiers (0.0-1.0)."
         },
+        "markdownInlineEditor.links.showEmoji": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show a chain icon after hyperlink text",
+          "markdownDescription": "Show a chain emoji (🔗) after decorated link text."
+        },
         "markdownInlineEditor.links.singleClickOpen": {
           "type": "boolean",
           "default": false,
           "description": "Open links and images with single click",
           "markdownDescription": "Single-click to open links and image links (no Ctrl+Click needed). May interfere with text selection."
-        },
-        "markdownInlineEditor.links.showEmoji": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show a chain icon after hyperlink text",
-          "markdownDescription": "Show a chain (🔗) icon after decorated link text."
         },
         "markdownInlineEditor.emojis.enabled": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,12 @@
           "description": "Open links and images with single click",
           "markdownDescription": "Single-click to open links and image links (no Ctrl+Click needed). May interfere with text selection."
         },
+        "markdownInlineEditor.links.showEmoji": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show a chain icon after hyperlink text",
+          "markdownDescription": "Show a chain (🔗) icon after decorated link text."
+        },
         "markdownInlineEditor.emojis.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,12 @@ export const config = {
         .getConfiguration(SECTION)
         .get<boolean>('links.singleClickOpen', false);
     },
+    /** Chain (🔗) icon after link text; off by default so raw markdown tables stay aligned. */
+    showEmoji(): boolean {
+      return vscode.workspace
+        .getConfiguration(SECTION)
+        .get<boolean>('links.showEmoji', false);
+    },
   },
   decorations: {
     ghostFaintOpacity(): number {

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -332,18 +332,23 @@ export function Heading6DecorationType(color?: string | ThemeColor) {
  * Sets cursor to pointer on hover to indicate clickability.
  *
  * @param {string | ThemeColor | undefined} color - Optional hex or theme color; when undefined uses textLink.foreground
+ * @param {boolean} showEmoji - When true, appends a chain icon after link text (can misalign monospace tables when off is preferred).
  * @returns {vscode.TextEditorDecorationType} A decoration type for links
  */
-export function LinkDecorationType(color?: string | ThemeColor) {
+export function LinkDecorationType(color?: string | ThemeColor, showEmoji = false) {
   const resolvedColor = color ?? new ThemeColor('textLink.foreground');
   return window.createTextEditorDecorationType({
     color: resolvedColor,
     textDecoration: 'underline',
     cursor: 'pointer',
-    after: {
-      contentText: ' 🔗',
-      color: resolvedColor,
-    },
+    ...(showEmoji
+      ? {
+          after: {
+            contentText: ' 🔗',
+            color: resolvedColor,
+          },
+        }
+      : {}),
   });
 }
 

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -91,6 +91,7 @@ export class Decorator {
       getHeading5Color: () => config.colors.heading5(),
       getHeading6Color: () => config.colors.heading6(),
       getLinkColor: () => config.colors.link(),
+      getLinkShowEmoji: () => config.links.showEmoji(),
       getListMarkerColor: () => config.colors.listMarker(),
       getInlineCodeColor: () => config.colors.inlineCode(),
       getInlineCodeBackgroundColor: () => config.colors.inlineCodeBackground(),
@@ -587,6 +588,16 @@ export class Decorator {
     this.decorationTypes.recreateCodeDecorationType();
 
     // Reapply decorations with the new decoration type
+    if (this.activeEditor && this.isMarkdownDocument()) {
+      this.updateDecorationsForSelection();
+    }
+  }
+
+  /**
+   * Recreates link decoration (underline + optional chain icon) when link emoji setting changes.
+   */
+  recreateLinkDecorationType(): void {
+    this.decorationTypes.recreateLinkDecorationType();
     if (this.activeEditor && this.isMarkdownDocument()) {
       this.updateDecorationsForSelection();
     }

--- a/src/decorator/__tests__/config-colors.test.ts
+++ b/src/decorator/__tests__/config-colors.test.ts
@@ -192,3 +192,25 @@ describe('config.colors', () => {
     });
   });
 });
+
+describe('config.links.showEmoji', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('defaults to false when unset', () => {
+    mockGet.mockImplementation((key: string, defaultValue?: unknown) => {
+      if (key === 'links.showEmoji') return defaultValue;
+      return undefined;
+    });
+    expect(config.links.showEmoji()).toBe(false);
+  });
+
+  it('returns true when enabled', () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'links.showEmoji') return true;
+      return undefined;
+    });
+    expect(config.links.showEmoji()).toBe(true);
+  });
+});

--- a/src/decorator/__tests__/decoration-colors.test.ts
+++ b/src/decorator/__tests__/decoration-colors.test.ts
@@ -87,10 +87,26 @@ describe('decoration creation with color (hex vs theme)', () => {
   });
 
   describe('syntax decorations (non-heading)', () => {
+    beforeEach(() => {
+      resetTextEditorDecorationTypeOptionsCapture();
+    });
+
     it('creates link decoration with hex and without', () => {
       expect(LinkDecorationType('#61afef')).toBeDefined();
       expect(LinkDecorationType()).toBeDefined();
       expect(LinkDecorationType(new ThemeColor('textLink.foreground'))).toBeDefined();
+    });
+
+    it('omits chain emoji after link text by default', () => {
+      LinkDecorationType('#61afef');
+      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
+      expect('after' in opts).toBe(false);
+    });
+
+    it('adds chain emoji after link text when showEmoji is true', () => {
+      LinkDecorationType('#61afef', true);
+      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
+      expect((opts.after as { contentText?: string }).contentText).toBe(' 🔗');
     });
 
     it('creates blockquote, list, code, emphasis decorations with hex or theme fallback', () => {

--- a/src/decorator/decoration-type-registry.ts
+++ b/src/decorator/decoration-type-registry.ts
@@ -49,6 +49,7 @@ type RegistryOptions = {
   getHeading5Color?: () => string | undefined;
   getHeading6Color?: () => string | undefined;
   getLinkColor?: () => string | undefined;
+  getLinkShowEmoji?: () => boolean;
   getListMarkerColor?: () => string | undefined;
   getInlineCodeColor?: () => string | undefined;
   getInlineCodeBackgroundColor?: () => string | undefined;
@@ -117,7 +118,10 @@ export class DecorationTypeRegistry {
     this.heading4DecorationType = Heading4DecorationType(this.options.getHeading4Color?.());
     this.heading5DecorationType = Heading5DecorationType(this.options.getHeading5Color?.());
     this.heading6DecorationType = Heading6DecorationType(this.options.getHeading6Color?.());
-    this.linkDecorationType = LinkDecorationType(this.options.getLinkColor?.());
+    this.linkDecorationType = LinkDecorationType(
+      this.options.getLinkColor?.(),
+      this.options.getLinkShowEmoji?.() ?? false,
+    );
     this.imageDecorationType = ImageDecorationType(this.options.getImageColor?.());
     this.mentionDecorationType = MentionDecorationType(this.options.getLinkColor?.());
     this.issueReferenceDecorationType = IssueReferenceDecorationType(this.options.getLinkColor?.());
@@ -191,6 +195,16 @@ export class DecorationTypeRegistry {
     );
   }
 
+  /** Recreates link decoration when link color or link emoji setting changes. */
+  recreateLinkDecorationType(): void {
+    this.recreateDecorationType(
+      this.linkDecorationType,
+      () => LinkDecorationType(this.options.getLinkColor?.(), this.options.getLinkShowEmoji?.() ?? false),
+      (t) => { this.linkDecorationType = t; },
+      'link',
+    );
+  }
+
   /**
    * Recreates all decoration types that depend on color settings or theme.
    * Call when config (markdownInlineEditor.colors) or active color theme changes.
@@ -202,7 +216,12 @@ export class DecorationTypeRegistry {
     this.recreateDecorationType(this.heading4DecorationType, () => Heading4DecorationType(this.options.getHeading4Color?.()), (t) => { this.heading4DecorationType = t; }, 'heading4');
     this.recreateDecorationType(this.heading5DecorationType, () => Heading5DecorationType(this.options.getHeading5Color?.()), (t) => { this.heading5DecorationType = t; }, 'heading5');
     this.recreateDecorationType(this.heading6DecorationType, () => Heading6DecorationType(this.options.getHeading6Color?.()), (t) => { this.heading6DecorationType = t; }, 'heading6');
-    this.recreateDecorationType(this.linkDecorationType, () => LinkDecorationType(this.options.getLinkColor?.()), (t) => { this.linkDecorationType = t; }, 'link');
+    this.recreateDecorationType(
+      this.linkDecorationType,
+      () => LinkDecorationType(this.options.getLinkColor?.(), this.options.getLinkShowEmoji?.() ?? false),
+      (t) => { this.linkDecorationType = t; },
+      'link',
+    );
     this.recreateDecorationType(this.blockquoteDecorationType, () => BlockquoteDecorationType(this.options.getBlockquoteColor?.()), (t) => { this.blockquoteDecorationType = t; }, 'blockquote');
     this.recreateDecorationType(this.listItemDecorationType, () => ListItemDecorationType(this.options.getListMarkerColor?.()), (t) => { this.listItemDecorationType = t; }, 'listItem');
     this.recreateDecorationType(this.orderedListItemDecorationType, () => OrderedListItemDecorationType(this.options.getListMarkerColor?.()), (t) => { this.orderedListItemDecorationType = t; }, 'orderedListItem');

--- a/src/registration/register-event-handlers.ts
+++ b/src/registration/register-event-handlers.ts
@@ -47,6 +47,10 @@ export function registerEventHandlers(
         linkClickHandler.setEnabled(config.links.singleClickOpen());
       }
 
+      if (event.affectsConfiguration('markdownInlineEditor.links.showEmoji')) {
+        decorator.recreateLinkDecorationType();
+      }
+
       if (event.affectsConfiguration('markdownInlineEditor.colors')) {
         decorator.recreateColorDependentTypes();
       }


### PR DESCRIPTION
## Summary
Adds `markdownInlineEditor.links.showEmoji` (default `false`) to toggle the chain (🔗) suffix on decorated links. Recreates link decoration when the setting changes.

I personally think this should be off by default but im willing to swap it.

Closes https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/87

Rebased onto #94 