### PR TITLE
chore(dependabot): remove invalid monthly day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: 1
       time: "09:00"
     open-pull-requests-limit: 10
     labels:
@@ -48,4 +47,3 @@ updates:
         update-types: ["version-update:semver-major"]
     # Versioning strategy
     versioning-strategy: increase
-


### PR DESCRIPTION
## Summary
- Remove the invalid integer `schedule.day` value from `.github/dependabot.yml`.
- Keep the existing monthly cadence and 09:00 schedule time.

## Root Cause
Dependabot expects `schedule.day` to be a weekday string, and that field is only used to choose a day for weekly schedules. The previous `day: 1` value caused GitHub to reject the configuration.

## Impact
Dependabot can parse the config again and will run monthly as intended. For `interval: "monthly"`, GitHub runs checks on the first day of each month by default.

## Validation
- `npm run validate`
- Verified the updated YAML parses to `interval: monthly` and `time: 09:00`.
- Checked GitHub Dependabot documentation for the `schedule.day` and monthly interval semantics.