### PR TITLE
fix(mermaid): lazy-init webview only when diagrams are rendered

### DIFF
--- a/src/mermaid/webview-manager.ts
+++ b/src/mermaid/webview-manager.ts
@@ -16,6 +16,7 @@ export class MermaidWebviewManager {
   private renderRequestCounter = 0;
   private messageHandlerDisposable: vscode.Disposable | undefined;
   private initTimeoutId: NodeJS.Timeout | undefined;
+  private ensureWebviewInFlight: Promise<void> | undefined;
   private _extensionContext: vscode.ExtensionContext | undefined;
 
   constructor() {
@@ -46,52 +47,52 @@ export class MermaidWebviewManager {
         { webviewOptions: { retainContextWhenHidden: true } }
       )
     );
-
-    // Open the mermaid view briefly to initialize it, then switch back
-    // Focus the view so VS Code calls resolveWebviewView() (hidden views are not resolved by opening the container only)
-    void this.ensureWebviewThenSwitchBack();
   }
 
   /**
-   * Focus the Mermaid view to trigger webview creation, wait for it (or 5s), then switch back to Explorer.
+   * Focus the Mermaid view to trigger webview creation on first use.
+   * Hidden views are not resolved until focused. Waits for readiness (or 5s), then switches back to Explorer.
    */
-  private ensureWebviewThenSwitchBack(): void {
+  async ensureWebviewReady(): Promise<void> {
+    if (this.webviewView) {
+      return;
+    }
+    if (!this.ensureWebviewInFlight) {
+      this.ensureWebviewInFlight = this.doEnsureWebviewThenSwitchBack();
+    }
+    await this.ensureWebviewInFlight;
+  }
+
+  private async doEnsureWebviewThenSwitchBack(): Promise<void> {
     const WEBVIEW_READY_TIMEOUT_MS = 5000;
     const SWITCH_BACK_DELAY_MS = 100;
 
-    vscode.commands
-      .executeCommand('mdInline.mermaidRenderer.focus')
-      .then(
-        () => {
-          // Wait for webview to be ready or timeout, then switch back
-          Promise.race([
-            this.webviewLoaded,
-            new Promise<void>((_, reject) =>
-              setTimeout(() => reject(new Error('timeout')), WEBVIEW_READY_TIMEOUT_MS)
-            ),
-          ])
-            .then(() => {
-              this.initTimeoutId = setTimeout(() => {
-                vscode.commands.executeCommand('workbench.view.explorer');
-                this.initTimeoutId = undefined;
-              }, SWITCH_BACK_DELAY_MS);
-            })
-            .catch((err: unknown) => {
-              if (err instanceof Error && err.message === 'timeout') {
-                logWarn('Mermaid: Webview not ready after opening view');
-              }
-              this.initTimeoutId = setTimeout(() => {
-                vscode.commands.executeCommand('workbench.view.explorer');
-                this.initTimeoutId = undefined;
-              }, SWITCH_BACK_DELAY_MS);
-            });
-        },
-        (err: unknown) => {
-          if (err !== undefined) {
-            logWarn('Mermaid: Failed to focus view', err);
-          }
-        }
-      );
+    try {
+      await vscode.commands.executeCommand('mdInline.mermaidRenderer.focus');
+    } catch (err: unknown) {
+      if (err !== undefined) {
+        logWarn('Mermaid: Failed to focus view', err);
+      }
+      return;
+    }
+
+    try {
+      await Promise.race([
+        this.webviewLoaded,
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error('timeout')), WEBVIEW_READY_TIMEOUT_MS)
+        ),
+      ]);
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message === 'timeout') {
+        logWarn('Mermaid: Webview not ready after opening view');
+      }
+    }
+
+    this.initTimeoutId = setTimeout(() => {
+      void vscode.commands.executeCommand('workbench.view.explorer');
+      this.initTimeoutId = undefined;
+    }, SWITCH_BACK_DELAY_MS);
   }
 
   /**
@@ -392,7 +393,7 @@ export class MermaidWebviewManager {
    * Wait for webview to be loaded
    */
   async waitForWebview(): Promise<void> {
-    await this.webviewLoaded;
+    await this.ensureWebviewReady();
     if (!this.webviewView) {
       throw new Error('Failed to create mermaid webview');
     }
@@ -422,6 +423,7 @@ export class MermaidWebviewManager {
     // Clear webview reference
     this.webviewView = undefined;
     this.resolveWebviewLoaded = undefined;
+    this.ensureWebviewInFlight = undefined;
   }
 }
 

--- a/src/mermaid/webview-manager.ts
+++ b/src/mermaid/webview-manager.ts
@@ -15,7 +15,8 @@ export class MermaidWebviewManager {
   private pendingRenders = new Map<string, PendingRender>();
   private renderRequestCounter = 0;
   private messageHandlerDisposable: vscode.Disposable | undefined;
-  private initTimeoutId: NodeJS.Timeout | undefined;
+  private visibilityDisposable: vscode.Disposable | undefined;
+  private hideViewTimeoutId: NodeJS.Timeout | undefined;
   private ensureWebviewInFlight: Promise<void> | undefined;
   private _extensionContext: vscode.ExtensionContext | undefined;
 
@@ -51,21 +52,21 @@ export class MermaidWebviewManager {
 
   /**
    * Focus the Mermaid view to trigger webview creation on first use.
-   * Hidden views are not resolved until focused. Waits for readiness (or 5s), then switches back to Explorer.
+   * Hidden views are not resolved until focused. Waits for readiness (or 5s).
+   * Auto-hide is handled by onDidChangeVisibility once the view becomes visible.
    */
   async ensureWebviewReady(): Promise<void> {
     if (this.webviewView) {
       return;
     }
     if (!this.ensureWebviewInFlight) {
-      this.ensureWebviewInFlight = this.doEnsureWebviewThenSwitchBack();
+      this.ensureWebviewInFlight = this.doEnsureWebviewReady();
     }
     await this.ensureWebviewInFlight;
   }
 
-  private async doEnsureWebviewThenSwitchBack(): Promise<void> {
+  private async doEnsureWebviewReady(): Promise<void> {
     const WEBVIEW_READY_TIMEOUT_MS = 5000;
-    const SWITCH_BACK_DELAY_MS = 100;
 
     try {
       await vscode.commands.executeCommand('mdInline.mermaidRenderer.focus');
@@ -88,11 +89,65 @@ export class MermaidWebviewManager {
         logWarn('Mermaid: Webview not ready after opening view');
       }
     }
+  }
 
-    this.initTimeoutId = setTimeout(() => {
-      void vscode.commands.executeCommand('workbench.view.explorer');
-      this.initTimeoutId = undefined;
-    }, SWITCH_BACK_DELAY_MS);
+  /**
+   * Schedule hiding the Mermaid view after it becomes visible.
+   * Waits for webview readiness, then switches back to Explorer and focuses the editor.
+   */
+  private scheduleHideView(): void {
+    const HIDE_VIEW_DELAY_MS = 100;
+
+    if (this.hideViewTimeoutId) {
+      clearTimeout(this.hideViewTimeoutId);
+    }
+
+    this.hideViewTimeoutId = setTimeout(() => {
+      this.hideViewTimeoutId = undefined;
+      void this.hideMermaidView();
+    }, HIDE_VIEW_DELAY_MS);
+  }
+
+  private async hideMermaidView(): Promise<void> {
+    const WEBVIEW_READY_TIMEOUT_MS = 5000;
+
+    try {
+      await Promise.race([
+        this.webviewLoaded,
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error('timeout')), WEBVIEW_READY_TIMEOUT_MS)
+        ),
+      ]);
+    } catch (err: unknown) {
+      if (err instanceof Error && err.message === 'timeout') {
+        logWarn('Mermaid: Webview not ready before hiding view');
+      }
+    }
+
+    try {
+      await vscode.commands.executeCommand('workbench.view.explorer');
+      await vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
+    } catch (err: unknown) {
+      if (err !== undefined) {
+        logWarn('Mermaid: Failed to hide view', err);
+      }
+    }
+  }
+
+  /**
+   * Track view visibility so the internal renderer panel auto-hides after being shown.
+   */
+  private attachVisibilityAutoHide(webviewView: vscode.WebviewView): void {
+    this.visibilityDisposable?.dispose();
+    this.visibilityDisposable = webviewView.onDidChangeVisibility(() => {
+      if (webviewView.visible) {
+        this.scheduleHideView();
+      }
+    });
+
+    if (webviewView.visible) {
+      this.scheduleHideView();
+    }
   }
 
   /**
@@ -100,6 +155,7 @@ export class MermaidWebviewManager {
    */
   setWebviewView(view: vscode.WebviewView): void {
     this.webviewView = view;
+    this.attachVisibilityAutoHide(view);
     // Resolve webviewLoaded immediately when webview is created
     this.resolveWebviewLoaded?.();
   }
@@ -403,11 +459,14 @@ export class MermaidWebviewManager {
    * Dispose and clean up resources
    */
   dispose(): void {
-    // Clear timeout if still pending
-    if (this.initTimeoutId) {
-      clearTimeout(this.initTimeoutId);
-      this.initTimeoutId = undefined;
+    // Clear hide timeout if still pending
+    if (this.hideViewTimeoutId) {
+      clearTimeout(this.hideViewTimeoutId);
+      this.hideViewTimeoutId = undefined;
     }
+
+    this.visibilityDisposable?.dispose();
+    this.visibilityDisposable = undefined;
     
     // Clear all pending render timeouts and reject promises
     for (const { reject, timeoutId } of this.pendingRenders.values()) {


### PR DESCRIPTION
### Summary

The Mermaid renderer webview no longer opens on extension startup. It is created on first diagram render and auto-hides so the sidebar stays on Explorer.

- **Changed:** Lazy Mermaid webview initialization
- **Changed:** Auto-hide after panel flash

## Mermaid webview lifecycle

Previously the extension focused the internal Mermaid panel during `initialize()`, which briefly switched the sidebar away from Explorer on every startup.

The webview is now created only when `waitForWebview()` runs for an actual render request. A visibility listener switches back to Explorer and refocuses the editor after the panel appears.