### PR TITLE
feat: make table CJK width ratio configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Everything works out of the box. If you want to tune the experience, open Settin
   - Style GitHub-style `@user` / `#123`; optional clickable targets when forge context is available. See [Mentions & references][feat-mentions-references].
 - **Emoji shortcodes** (`emojis.enabled`, default `true`)
   - Disable if you prefer seeing `:shortcode:` text.
+- **Table CJK width** (`tables.cjkWidthRatio`, default `2.25`)
+  - Tune visual GFM table alignment for your editor font; set `2.0` when CJK glyphs render close to two ASCII columns.
 - **Syntax colors** (`colors.heading1` … `colors.checkbox`, 15 options including `inlineCodeBackground`)
   - Optional hex overrides (e.g. `#e06c75`) for headings, links, list markers, inline code, inline code background, emphasis, blockquote, image, horizontal rule, checkbox. Unset or invalid values use theme-derived defaults (for headings, unset keeps the editor’s markdown heading syntax colors rather than forcing a single foreground). See [Customizable Syntax Colors][feat-customizable-syntax-colors].
 
@@ -154,7 +156,8 @@ Everything works out of the box. If you want to tune the experience, open Settin
   "markdownInlineEditor.decorations.ghostFaintOpacity": 0.25,
   "markdownInlineEditor.defaultBehaviors.diffView.applyDecorations": false,
   "markdownInlineEditor.links.singleClickOpen": false,
-  "markdownInlineEditor.emojis.enabled": true
+  "markdownInlineEditor.emojis.enabled": true,
+  "markdownInlineEditor.tables.cjkWidthRatio": 2.0
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -136,6 +136,14 @@
           "description": "Render LaTeX math inline ($...$ and $$...$$)",
           "markdownDescription": "Render LaTeX math inline ($...$ and $$...$$). When disabled, math delimiters are shown as plain text."
         },
+        "markdownInlineEditor.tables.cjkWidthRatio": {
+          "type": "number",
+          "default": 2.25,
+          "minimum": 1,
+          "maximum": 3,
+          "description": "CJK character width ratio for visual table alignment",
+          "markdownDescription": "Display-width ratio used for CJK characters when padding visual GFM table columns. The default `2.25` preserves the previous `2 + 0.25` correction. Set to `2.0` when your editor font renders CJK close to two ASCII columns."
+        },
         "markdownInlineEditor.orderedLists.autoNumber": {
           "type": "boolean",
           "default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ const SECTION = 'markdownInlineEditor' as const;
 
 /** Matches `#` + 3, 4, 6, or 8 hex digits (#RGB, #RGBA, #RRGGBB, #RRGGBBAA). Invalid values are treated as unset. */
 const HEX_COLOR_REGEX = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{4}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+const DEFAULT_TABLE_CJK_WIDTH_RATIO = 2.25;
 
 function parseHexColor(value: string | undefined | null): string | undefined {
   if (value === undefined || value === null || typeof value !== 'string') {
@@ -17,6 +18,17 @@ function getColorConfig(key: string): string | undefined {
   return parseHexColor(
     vscode.workspace.getConfiguration(SECTION).get<string>(`colors.${key}`)
   );
+}
+
+function getNumberConfig(key: string, defaultValue: number, min: number, max: number): number {
+  const value = vscode.workspace
+    .getConfiguration(SECTION)
+    .get<unknown>(key, defaultValue);
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numeric)) {
+    return defaultValue;
+  }
+  return Math.min(max, Math.max(min, numeric));
 }
 
 export const config = {
@@ -69,6 +81,12 @@ export const config = {
       return vscode.workspace
         .getConfiguration(SECTION)
         .get<boolean>('math.enabled', true);
+    },
+  },
+  tables: {
+    /** Display-width ratio for CJK glyphs when padding visual GFM table columns. */
+    cjkWidthRatio(): number {
+      return getNumberConfig('tables.cjkWidthRatio', DEFAULT_TABLE_CJK_WIDTH_RATIO, 1, 3);
     },
   },
   orderedLists: {

--- a/src/decorator/__tests__/config-table.test.ts
+++ b/src/decorator/__tests__/config-table.test.ts
@@ -1,0 +1,53 @@
+import { workspace } from '../../test/__mocks__/vscode';
+import { config } from '../../config';
+
+const mockGet = vi.fn();
+const mockGetConfiguration = vi.fn().mockReturnValue({ get: mockGet });
+
+(workspace as any).getConfiguration = mockGetConfiguration;
+
+describe('config.tables.cjkWidthRatio', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('defaults to 2.25 when unset', () => {
+    mockGet.mockImplementation((key: string, defaultValue?: unknown) => {
+      if (key === 'tables.cjkWidthRatio') return defaultValue;
+      return undefined;
+    });
+    expect(config.tables.cjkWidthRatio()).toBe(2.25);
+  });
+
+  it('returns configured numeric value', () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'tables.cjkWidthRatio') return 2;
+      return undefined;
+    });
+    expect(config.tables.cjkWidthRatio()).toBe(2);
+  });
+
+  it('clamps values below minimum', () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'tables.cjkWidthRatio') return 0.5;
+      return undefined;
+    });
+    expect(config.tables.cjkWidthRatio()).toBe(1);
+  });
+
+  it('clamps values above maximum', () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'tables.cjkWidthRatio') return 4;
+      return undefined;
+    });
+    expect(config.tables.cjkWidthRatio()).toBe(3);
+  });
+
+  it('falls back to default for non-numeric values', () => {
+    mockGet.mockImplementation((key: string) => {
+      if (key === 'tables.cjkWidthRatio') return 'wide';
+      return undefined;
+    });
+    expect(config.tables.cjkWidthRatio()).toBe(2.25);
+  });
+});

--- a/src/parser/__tests__/parser-table.test.ts
+++ b/src/parser/__tests__/parser-table.test.ts
@@ -1,4 +1,5 @@
 import { MarkdownParser, DecorationRange } from '../../parser';
+import { config } from '../../config';
 
 describe('MarkdownParser - Tables', () => {
   let parser: MarkdownParser;
@@ -102,6 +103,29 @@ describe('MarkdownParser - Tables', () => {
       // All cells should have replacement text
       cells.forEach((c) => {
         expect(c.replacement).toBeDefined();
+      });
+    });
+
+    describe('when tables.cjkWidthRatio is configured', () => {
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it('should use the configured ratio for visual column width calculation', () => {
+        const md = '| A |\n|---|\n| \u3042\u3042 |';
+        const cjkWidthRatio = vi.spyOn(config.tables, 'cjkWidthRatio');
+
+        cjkWidthRatio.mockReturnValue(2);
+        const twoColumnCells = byType(parser.extractDecorations(md), 'tableCell');
+        const twoColumnHeader = twoColumnCells.find((c) => c.replacement?.includes('A'));
+        expect(twoColumnHeader).toBeDefined();
+        expect(twoColumnHeader!.replacement!.length).toBe(6);
+
+        cjkWidthRatio.mockReturnValue(3);
+        const threeColumnCells = byType(parser.extractDecorations(md), 'tableCell');
+        const threeColumnHeader = threeColumnCells.find((c) => c.replacement?.includes('A'));
+        expect(threeColumnHeader).toBeDefined();
+        expect(threeColumnHeader!.replacement!.length).toBe(8);
       });
     });
   });

--- a/src/parser/core.ts
+++ b/src/parser/core.ts
@@ -1294,17 +1294,14 @@ export class MarkdownParser {
    * (no markdown markers — callers use `extractCellPlainText` / `detectCellStyle` paths).
    *
    * CJK wide characters (Unicode ranges U+2E80–U+9FFF, U+F900–U+FAFF,
-   * U+FE30–U+FE4F, U+20000–U+2FA1F) count as 2 columns; all others as 1.
-   *
-   * Adds a small per-CJK-character correction because VS Code's `before`
-   * pseudo-element renders CJK glyphs slightly wider than exactly 2x
-   * ASCII width in most monospace fonts.
+   * U+FE30–U+FE4F, U+20000–U+2FA1F) use the configured table CJK width
+   * ratio; all other characters count as 1 column.
    *
    * @param plain - Already-unmarked cell display text
    * @returns Estimated width in monospace columns
    */
-  private measureTextWidth(plain: string): number {
-    return measureTextWidthHelper(plain);
+  private measureTextWidth(plain: string, cjkWidthRatio: number): number {
+    return measureTextWidthHelper(plain, cjkWidthRatio);
   }
 
   /**
@@ -1363,8 +1360,12 @@ export class MarkdownParser {
    * @param source - The full normalized document text
    * @returns Array of column widths (one per column, minimum 3)
    */
-  private computeColumnWidths(tableNode: Table, source: string): number[] {
-    return computeColumnWidthsHelper(tableNode, source);
+  private computeColumnWidths(
+    tableNode: Table,
+    source: string,
+    cjkWidthRatio: number,
+  ): number[] {
+    return computeColumnWidthsHelper(tableNode, source, cjkWidthRatio);
   }
 
   /**
@@ -1395,7 +1396,8 @@ export class MarkdownParser {
 
     const tableStart = node.position!.start.offset!;
     const tableEnd = node.position!.end.offset!;
-    const colWidths = this.computeColumnWidths(node, text);
+    const cjkWidthRatio = config.tables.cjkWidthRatio();
+    const colWidths = this.computeColumnWidths(node, text, cjkWidthRatio);
     const colAligns = node.align ?? [];
 
     this.addScope(scopes, tableStart, tableEnd, "table");
@@ -1449,7 +1451,7 @@ export class MarkdownParser {
         const displayContent = (astCell && !showRaw)
           ? this.extractCellPlainText(astCell)
           : trimmedContent;
-        const displayWidth = this.measureTextWidth(displayContent);
+        const displayWidth = this.measureTextWidth(displayContent, cjkWidthRatio);
         const totalPad = Math.max(0, colWidth - displayWidth);
         const align = i < colAligns.length ? colAligns[i] : null;
 

--- a/src/parser/tables.ts
+++ b/src/parser/tables.ts
@@ -71,9 +71,11 @@ export function detectCellStyle(
   return undefined;
 }
 
-export function measureTextWidth(plain: string): number {
+export function measureTextWidth(
+  plain: string,
+  cjkWidthRatio: number,
+): number {
   let width = 0;
-  let cjkCount = 0;
   for (const char of plain) {
     const code = char.codePointAt(0)!;
     if (
@@ -82,13 +84,12 @@ export function measureTextWidth(plain: string): number {
       (code >= 0xfe30 && code <= 0xfe4f) ||
       (code >= 0x20000 && code <= 0x2fa1f)
     ) {
-      width += 2;
-      cjkCount++;
+      width += cjkWidthRatio;
     } else {
       width += 1;
     }
   }
-  return width + Math.ceil(cjkCount * 0.25);
+  return Math.ceil(width);
 }
 
 export function findPipePositions(
@@ -163,7 +164,11 @@ export function trimLineEnd(text: string, lineStart: number, lineEnd: number): n
   return end;
 }
 
-export function computeColumnWidths(tableNode: Table, source: string): number[] {
+export function computeColumnWidths(
+  tableNode: Table,
+  source: string,
+  cjkWidthRatio: number,
+): number[] {
   let numCols = 0;
 
   for (const row of tableNode.children) {
@@ -193,7 +198,7 @@ export function computeColumnWidths(tableNode: Table, source: string): number[] 
       const displayText = (astCell && !showRaw)
         ? extractCellPlainText(astCell)
         : cellText;
-      const width = measureTextWidth(displayText);
+      const width = measureTextWidth(displayText, cjkWidthRatio);
       if (width > widths[i]) widths[i] = width;
     }
   }

--- a/src/registration/__tests__/register-event-handlers.test.ts
+++ b/src/registration/__tests__/register-event-handlers.test.ts
@@ -19,6 +19,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      clearCache: vi.fn(),
     };
     const linkClickHandler = {
       setEnabled: vi.fn(),
@@ -78,6 +79,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      clearCache: vi.fn(),
     };
 
     registerEventHandlers(decorator as any, { setEnabled: vi.fn() } as any);
@@ -126,6 +128,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      clearCache: vi.fn(),
     };
     const linkClickHandler = {
       setEnabled: vi.fn(),
@@ -139,6 +142,7 @@ describe('registerEventHandlers', () => {
       'markdownInlineEditor.decorations.frontmatterDelimiterOpacity',
       'markdownInlineEditor.decorations.codeBlockLanguageOpacity',
       'markdownInlineEditor.links.singleClickOpen',
+      'markdownInlineEditor.tables.cjkWidthRatio',
       'markdownInlineEditor.colors',
       'editor.fontSize',
       'editor.lineHeight',
@@ -155,6 +159,7 @@ describe('registerEventHandlers', () => {
     expect(decorator.recreateFrontmatterDelimiterDecorationType).toHaveBeenCalled();
     expect(decorator.recreateCodeBlockLanguageDecorationType).toHaveBeenCalled();
     expect(linkClickHandler.setEnabled).toHaveBeenCalledWith(true);
+    expect(decorator.clearCache).toHaveBeenCalledTimes(1);
     expect(decorator.recreateColorDependentTypes).toHaveBeenCalledTimes(2);
     expect(decorator.clearMathDecorationCache).toHaveBeenCalledTimes(1);
   });

--- a/src/registration/register-event-handlers.ts
+++ b/src/registration/register-event-handlers.ts
@@ -51,6 +51,11 @@ export function registerEventHandlers(
         decorator.recreateLinkDecorationType();
       }
 
+      if (event.affectsConfiguration('markdownInlineEditor.tables.cjkWidthRatio')) {
+        decorator.clearCache();
+        decorator.updateDecorationsForSelection();
+      }
+
       if (event.affectsConfiguration('markdownInlineEditor.colors')) {
         decorator.recreateColorDependentTypes();
       }


### PR DESCRIPTION
## Summary
- Add a new `markdownInlineEditor.tables.cjkWidthRatio` setting to control the display-width ratio used for CJK characters in GFM table alignment.
- Replace the previous fixed ratio with the configured value when computing table column widths.
- Re-run table decoration updates when the setting changes.
- Update documentation and tests to cover the new behavior.

## Why
The previous fixed ratio does not fit every editor font. Some fonts render CJK glyphs closer to 2 ASCII columns, while others need a larger correction. Making the ratio configurable lets users tune table alignment for their font.

## Tests
- Added/updated config tests for `tables.cjkWidthRatio`
- Added/updated parser table width tests
- Added/updated configuration change handling tests
- Updated README examples and configuration docs

## Capture

<img width="261" height="196" alt="image" src="https://github.com/user-attachments/assets/d3dd4a31-c4a9-47fe-a419-03e19b8180e8" />

<img width="719" height="178" alt="image" src="https://github.com/user-attachments/assets/31c60b1e-78b1-47c5-8b83-858d8a2a42dd" />

<img width="300" height="218" alt="image" src="https://github.com/user-attachments/assets/1a1218f3-341f-4fdf-8ca5-05e51d330f77" />


