### PR TITLE
fix: resolve five open GitHub issues (#80, #92, #95, #108, #114)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,12 @@
           "description": "Opacity for ghost faint decorations",
           "markdownDescription": "Opacity of syntax markers when cursor is on a line (0.0-1.0)."
         },
+        "markdownInlineEditor.decorations.ghostLinks.collapse": {
+          "type": "boolean",
+          "default": false,
+          "description": "Collapse ghost-state link syntax to zero width",
+          "markdownDescription": "When enabled, link URL syntax on the active line is fully hidden (zero width) instead of shown faintly. Only the link under the cursor expands to raw markdown."
+        },
         "markdownInlineEditor.decorations.frontmatterDelimiterOpacity": {
           "type": "number",
           "default": 0.3,
@@ -135,6 +141,14 @@
           "default": true,
           "description": "Render LaTeX math inline ($...$ and $$...$$)",
           "markdownDescription": "Render LaTeX math inline ($...$ and $$...$$). When disabled, math delimiters are shown as plain text."
+        },
+        "markdownInlineEditor.mermaid.maxWidthColumns": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 500,
+          "description": "Maximum Mermaid diagram width in columns",
+          "markdownDescription": "Maximum width for scaling Mermaid diagrams, in monospace columns. `0` (default) estimates width from the visible editor viewport."
         },
         "markdownInlineEditor.orderedLists.autoNumber": {
           "type": "boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,11 @@ export const config = {
         .getConfiguration(SECTION)
         .get<number>('decorations.ghostFaintOpacity', 0.3);
     },
+    ghostLinksCollapse(): boolean {
+      return vscode.workspace
+        .getConfiguration(SECTION)
+        .get<boolean>('decorations.ghostLinks.collapse', false);
+    },
     frontmatterDelimiterOpacity(): number {
       return vscode.workspace
         .getConfiguration(SECTION)
@@ -69,6 +74,14 @@ export const config = {
       return vscode.workspace
         .getConfiguration(SECTION)
         .get<boolean>('math.enabled', true);
+    },
+  },
+  mermaid: {
+    /** Override max diagram width in columns; 0 uses auto viewport estimate. */
+    maxWidthColumns(): number {
+      return vscode.workspace
+        .getConfiguration(SECTION)
+        .get<number>('mermaid.maxWidthColumns', 0);
     },
   },
   orderedLists: {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,7 +1,7 @@
 import { DecorationOptions, Range, TextEditor, TextDocument, TextDocumentChangeEvent, window, TextEditorSelectionChangeKind, Memento } from 'vscode';
 import { DecorationRange, DecorationType, MermaidBlock, MathRegion, ScopeRange } from './parser';
 import { config } from './config';
-import { isDiffLikeUri, isDiffViewVisible } from './diff-context';
+import { isDiffLikeUri } from './diff-context';
 import { MarkdownParseCache } from './markdown-parse-cache';
 import {
   applyFilteredDecorations,
@@ -21,6 +21,7 @@ import { MermaidHoverIndicatorDecorationType } from './decorations';
 import { isSupportedMarkdownLanguage } from './language-support';
 import { logDebug, logPerformanceMetric } from './logging';
 import { applyMathDecorationsForEditor } from './decorator/math-region-application';
+import { clearMermaidDecorationCache as clearMermaidRenderCache } from './mermaid/mermaid-renderer';
 
 /**
  * Performance and caching constants.
@@ -381,28 +382,22 @@ export class Decorator {
   }
 
   /**
-   * Detects if the current editor is viewing a diff.
-   * 
-   * For side-by-side diff views, checks ALL visible editors to see if any
-   * are in a diff context. This ensures both sides of the diff have
-   * decorations disabled, regardless of which side is currently active.
-   * 
+   * Detects if the active editor is viewing a diff.
+   *
+   * Only the active editor's document URI is checked so decorations remain
+   * enabled on a normal markdown file open beside an unrelated diff preview (#95).
+   * Side-by-side diff of the same file still skips decorations because both panes
+   * use diff URIs.
+   *
    * @private
-   * @returns {boolean} True if editor is in diff mode
+   * @returns {boolean} True if the active editor is in diff mode
    */
   private isDiffEditor(): boolean {
     if (!this.activeEditor) {
       return false;
     }
 
-    if (isDiffLikeUri(this.activeEditor.document.uri)) {
-      return true;
-    }
-
-    // For side-by-side diff views, check all visible editors
-    // If ANY visible editor is in a diff context, we're in a diff view
-    // This ensures both sides of the diff have decorations disabled
-    return isDiffViewVisible(window.visibleTextEditors);
+    return isDiffLikeUri(this.activeEditor.document.uri);
   }
 
   /**
@@ -490,7 +485,8 @@ export class Decorator {
       decorations,
       scopes,
       originalText,
-      (startPos, endPos, text) => this.createRange(startPos, endPos, text)
+      (startPos, endPos, text) => this.createRange(startPos, endPos, text),
+      { ghostLinksCollapse: config.decorations.ghostLinksCollapse() }
     );
   }
 
@@ -515,6 +511,14 @@ export class Decorator {
     if (this.activeEditor) {
       this.mathDecorations.clear(this.activeEditor);
     }
+    this.updateDecorationsForSelection();
+  }
+
+  /**
+   * Clears the Mermaid decoration cache and forces re-render at the current viewport width.
+   */
+  clearMermaidDecorationCache(): void {
+    clearMermaidRenderCache();
     this.updateDecorationsForSelection();
   }
 

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,4 +1,4 @@
-import { DecorationOptions, Range, TextEditor, TextDocument, TextDocumentChangeEvent, window, TextEditorSelectionChangeKind, Memento } from 'vscode';
+import { DecorationOptions, Range, TextEditor, TextDocument, TextDocumentChangeEvent, TextEditorSelectionChangeKind, Memento } from 'vscode';
 import { DecorationRange, DecorationType, MermaidBlock, MathRegion, ScopeRange } from './parser';
 import { config } from './config';
 import { isDiffLikeUri } from './diff-context';
@@ -219,6 +219,13 @@ export class Decorator {
     const uri = this.activeEditor?.document.uri.toString();
     if (!uri) { return true; }
     return this.isEnabledForUri(uri);
+  }
+
+  /**
+   * Exposed for integration tests — whether the active editor is a diff/merge document.
+   */
+  isActiveEditorDiffView(): boolean {
+    return this.isDiffEditor();
   }
 
   /**

--- a/src/decorator/__tests__/decorator-diff-mode.test.ts
+++ b/src/decorator/__tests__/decorator-diff-mode.test.ts
@@ -1,5 +1,5 @@
 import { TextDocument, Uri } from '../../test/__mocks__/vscode';
-import { isDiffLikeUri } from '../../diff-context';
+import { isDiffLikeUri, isDiffViewVisible } from '../../diff-context';
 
 /**
  * Tests for diff mode detection functionality.
@@ -78,6 +78,34 @@ describe('Decorator - Diff Mode', () => {
     it('should not identify file scheme as diff scheme', () => {
       const fileUri = Uri.file('test.md');
       expect(isDiffLikeUri(fileUri as any)).toBe(false);
+    });
+  });
+
+  describe('active editor diff detection (#95)', () => {
+    /** Mirrors Decorator.isDiffEditor() — only the active document URI matters. */
+    function isActiveEditorInDiffMode(uri: ReturnType<typeof Uri.file>): boolean {
+      return isDiffLikeUri(uri as any);
+    }
+
+    it('should not skip decorations on markdown when another visible editor is a diff', () => {
+      const markdownUri = Uri.file('notes.md');
+      const diffUri = Uri.parse('git:/path/to/other.ts');
+
+      const visibleEditors = [
+        { document: { uri: diffUri } },
+        { document: { uri: markdownUri } },
+      ];
+
+      // Old behavior: any visible diff editor blocked all decoration updates.
+      expect(isDiffViewVisible(visibleEditors as any)).toBe(true);
+
+      // Fixed behavior: only the active editor URI is checked.
+      expect(isActiveEditorInDiffMode(markdownUri)).toBe(false);
+    });
+
+    it('should skip decorations when the active editor itself is a diff', () => {
+      const diffUri = Uri.parse('git:/path/to/file.md');
+      expect(isActiveEditorInDiffMode(diffUri as any)).toBe(true);
     });
   });
 });

--- a/src/decorator/__tests__/decorator-filtering.test.ts
+++ b/src/decorator/__tests__/decorator-filtering.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../parser', () => ({
 import { Decorator } from '../../decorator';
 import type { DecorationRange, DecorationType } from '../../parser';
 import { isMarkerDecorationType } from '../decoration-categories';
+import { filterDecorationsForEditor } from '../visibility-model';
 import { TextDocument, TextEditor, Selection, Position, Uri, Range } from '../../test/__mocks__/vscode';
 
 type ScopeEntry = {
@@ -572,6 +573,47 @@ describe('Decorator filtering behavior', () => {
     expect(filtered.get('bold')?.length).toBe(1);
     expect(filtered.get('hide')?.length).toBe(2);
     expect(filtered.has('ghostFaint')).toBe(false);
+  });
+
+  it('collapses ghost-state link syntax when ghostLinks.collapse is enabled (#114)', () => {
+    const text = '[FAQ](https://example.com/faq) and [Reviews](https://example.com/reviews)';
+    const linkOneEnd = text.indexOf(')') + 1;
+    const linkTwoStart = text.indexOf('[Reviews]');
+    const decorations: DecorationRange[] = [
+      { startPos: 0, endPos: 1, type: 'hide' },
+      { startPos: 1, endPos: 4, type: 'link', url: 'https://example.com/faq' },
+      { startPos: 4, endPos: 5, type: 'hide' },
+      { startPos: 5, endPos: 6, type: 'hide' },
+      { startPos: 6, endPos: 28, type: 'hide' },
+      { startPos: 28, endPos: 29, type: 'hide' },
+      { startPos: linkTwoStart, endPos: linkTwoStart + 1, type: 'hide' },
+      { startPos: linkTwoStart + 1, endPos: linkTwoStart + 8, type: 'link', url: 'https://example.com/reviews' },
+      { startPos: linkTwoStart + 8, endPos: linkTwoStart + 9, type: 'hide' },
+      { startPos: linkTwoStart + 9, endPos: linkTwoStart + 10, type: 'hide' },
+      { startPos: linkTwoStart + 10, endPos: text.length - 1, type: 'hide' },
+      { startPos: text.length - 1, endPos: text.length, type: 'hide' },
+    ];
+
+    const document = new TextDocument(Uri.file('test.md'), 'markdown', 1, text);
+    const selection = new Selection(new Position(0, text.length - 1), new Position(0, text.length - 1));
+    const editor = new TextEditor(document, [selection]);
+    const scopes = [
+      { startPos: 0, endPos: linkOneEnd, range: new Range(document.positionAt(0), document.positionAt(linkOneEnd)), kind: 'link' },
+      { startPos: linkTwoStart, endPos: text.length, range: new Range(document.positionAt(linkTwoStart), document.positionAt(text.length)), kind: 'link' },
+    ];
+
+    const filtered = filterDecorationsForEditor(
+      editor as any,
+      decorations,
+      scopes as any,
+      text,
+      (startPos, endPos) => new Range(document.positionAt(startPos), document.positionAt(endPos)),
+      { ghostLinksCollapse: true },
+    );
+
+    expect(filtered.get('link')?.length).toBe(2);
+    expect(filtered.has('ghostFaint')).toBe(false);
+    expect((filtered.get('hide')?.length ?? 0)).toBeGreaterThan(0);
   });
 });
 

--- a/src/decorator/mermaid-update-coordinator.ts
+++ b/src/decorator/mermaid-update-coordinator.ts
@@ -3,6 +3,7 @@ import { ColorThemeKind, Position, Range, TextEditor, window, workspace } from '
 import type { MermaidBlock } from '../parser';
 import { mapNormalizedToOriginal } from '../position-mapping';
 import { renderMermaidSvg, svgToDataUri, createErrorSvg } from '../mermaid/mermaid-renderer';
+import { bucketWidthForCache, estimateEditorContentWidthPx } from '../mermaid/editor-width';
 import { MermaidDiagramDecorations } from './mermaid-diagram-decorations';
 import { createRange, isSelectionOrCursorInsideOffsets } from './editor-decoration-applier';
 import { logWarn } from '../logging';
@@ -11,6 +12,7 @@ type MermaidBlockKeyCacheEntry = {
   theme: 'default' | 'dark';
   fontFamily?: string;
   numLines: number;
+  maxWidthBucket: number;
   key: string;
 };
 
@@ -19,21 +21,23 @@ const mermaidBlockKeyCache = new WeakMap<MermaidBlock, MermaidBlockKeyCacheEntry
 function getMermaidBlockCacheKey(
   block: MermaidBlock,
   theme: 'default' | 'dark',
-  fontFamily?: string
+  fontFamily: string | undefined,
+  maxWidthBucket: number,
 ): string {
   const cached = mermaidBlockKeyCache.get(block);
   if (
     cached &&
     cached.theme === theme &&
     cached.fontFamily === fontFamily &&
-    cached.numLines === block.numLines
+    cached.numLines === block.numLines &&
+    cached.maxWidthBucket === maxWidthBucket
   ) {
     return cached.key;
   }
 
-  const keySource = `${block.source}\n${theme}\n${fontFamily ?? ''}\n${block.numLines}`;
+  const keySource = `${block.source}\n${theme}\n${fontFamily ?? ''}\n${block.numLines}\n${maxWidthBucket}`;
   const key = createHash('sha256').update(keySource).digest('hex');
-  mermaidBlockKeyCache.set(block, { theme, fontFamily, numLines: block.numLines, key });
+  mermaidBlockKeyCache.set(block, { theme, fontFamily, numLines: block.numLines, maxWidthBucket, key });
   return key;
 }
 
@@ -87,6 +91,8 @@ export class MermaidUpdateCoordinator {
       ? 'dark'
       : 'default';
     const fontFamily = workspace.getConfiguration('editor').get<string>('fontFamily');
+    const maxWidth = estimateEditorContentWidthPx(editor);
+    const maxWidthBucket = bucketWidthForCache(maxWidth);
 
     const rangesByKey = new Map<string, Range[]>();
     const dataUrisByKey = new Map<string, string>();
@@ -122,12 +128,17 @@ export class MermaidUpdateCoordinator {
           new Position(contentStartPos.line, indicatorEndChar)
         );
 
-        const key = getMermaidBlockCacheKey(block, theme, fontFamily);
+        const key = getMermaidBlockCacheKey(block, theme, fontFamily, maxWidthBucket);
         let dataUriPromise = dataUriPromisesByKey.get(key);
         if (!dataUriPromise) {
           dataUriPromise = (async () => {
             try {
-              const svg = await renderMermaidSvg(block.source, { theme, fontFamily, numLines: block.numLines });
+              const svg = await renderMermaidSvg(block.source, {
+                theme,
+                fontFamily,
+                numLines: block.numLines,
+                maxWidth,
+              });
               return svgToDataUri(svg);
             } catch (error) {
               logWarn('Mermaid render failed', error);

--- a/src/decorator/visibility-model.ts
+++ b/src/decorator/visibility-model.ts
@@ -12,12 +12,17 @@ export type ScopeEntry = {
 type RangeFactory = (startPos: number, endPos: number, originalText: string) => Range | null;
 type FilteredDecoration = Range | DecorationOptions;
 
+export type VisibilityFilterOptions = {
+  ghostLinksCollapse?: boolean;
+};
+
 export function filterDecorationsForEditor(
   editor: TextEditor,
   decorations: DecorationRange[],
   scopes: ScopeEntry[],
   originalText: string,
-  rangeFactory: RangeFactory
+  rangeFactory: RangeFactory,
+  options: VisibilityFilterOptions = {},
 ): Map<DecorationType, FilteredDecoration[]> {
   const selectedRanges: Range[] = [];
   const cursorPositions: Position[] = [];
@@ -89,6 +94,8 @@ export function filterDecorationsForEditor(
   const filtered = new Map<DecorationType, FilteredDecoration[]>();
   const ghostFaintRanges: Range[] = [];
   const selectionOverlayRanges: Range[] = [];
+  const linkScopes = scopes.filter((scope) => scope.kind === 'link');
+  const ghostLinksCollapse = options.ghostLinksCollapse === true;
 
   const selectionOrCursorOverlaps = (range: Range): boolean => {
     const selectionOverlaps = selectedRanges.some((selection) => {
@@ -165,6 +172,15 @@ export function filterDecorationsForEditor(
         continue;
       }
       if (isActiveLine) {
+        if (
+          ghostLinksCollapse &&
+          rangeOverlapsLinkScope(decoration.startPos, decoration.endPos, linkScopes)
+        ) {
+          const ranges = filtered.get(decoration.type) || [];
+          ranges.push(range);
+          filtered.set(decoration.type, ranges);
+          continue;
+        }
         // Ghost state: show faint markers on active lines
         ghostFaintRanges.push(range);
         continue;
@@ -349,4 +365,12 @@ function rangeIntersectsAny(range: Range, ranges: Range[]): boolean {
     const intersection = range.intersection(candidate);
     return intersection !== undefined;
   });
+}
+
+function rangeOverlapsLinkScope(
+  startPos: number,
+  endPos: number,
+  linkScopes: ScopeEntry[],
+): boolean {
+  return linkScopes.some((scope) => startPos < scope.endPos && endPos > scope.startPos);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,10 @@ import { MarkdownParseCache } from './markdown-parse-cache';
 import { MarkdownParser } from './parser';
 import { disposeMermaidRenderer, initMermaidRenderer } from './mermaid/mermaid-renderer';
 import { processSvg } from './mermaid/svg-processor';
+import { estimateEditorContentWidthPx, bucketWidthForCache } from './mermaid/editor-width';
+import { scanMathRegions } from './math/math-scanner';
+import { isDiffLikeUri } from './diff-context';
+import { filterDecorationsForEditor } from './decorator/visibility-model';
 import { checkRecommendedExtensions } from './recommendations';
 import { registerEventHandlers } from './registration/register-event-handlers';
 import { registerProviders } from './registration/register-providers';
@@ -26,6 +30,14 @@ export type ExtensionApi = {
   /** SVG processing utilities exposed for integration tests. */
   svgProcessor: {
     processSvg: (svgString: string, height: number, maxWidth?: number) => string;
+  };
+  /** Pure helpers exposed for integration / E2E assertions. */
+  testUtils: {
+    scanMathRegions: typeof scanMathRegions;
+    estimateEditorContentWidthPx: typeof estimateEditorContentWidthPx;
+    bucketWidthForCache: typeof bucketWidthForCache;
+    isDiffLikeUri: typeof isDiffLikeUri;
+    filterDecorationsForEditor: typeof filterDecorationsForEditor;
   };
 };
 
@@ -57,7 +69,18 @@ export function activate(context: vscode.ExtensionContext): ExtensionApi {
     { dispose: () => disposeLogger() },
   );
 
-  return { parseCache, decorator, svgProcessor: { processSvg } };
+  return {
+    parseCache,
+    decorator,
+    svgProcessor: { processSvg },
+    testUtils: {
+      scanMathRegions,
+      estimateEditorContentWidthPx,
+      bucketWidthForCache,
+      isDiffLikeUri,
+      filterDecorationsForEditor,
+    },
+  };
 }
 
 export function deactivate(): void {

--- a/src/math/__tests__/math-scanner.test.ts
+++ b/src/math/__tests__/math-scanner.test.ts
@@ -142,3 +142,27 @@ describe('scanMathRegions - fence-aware behavior', () => {
     expect(scanMathRegions(text)).toHaveLength(0);
   });
 });
+
+describe('scanMathRegions - inline code span behavior', () => {
+  it('skips $...$ inside inline backtick code (#92)', () => {
+    expect(scanMathRegions('`${FOO}`')).toEqual([]);
+    expect(scanMathRegions('`$100$`')).toEqual([]);
+    expect(scanMathRegions('`const s = "$x$"`')).toEqual([]);
+  });
+
+  it('still detects math outside inline code on the same line', () => {
+    const text = 'Before $a$ and `const b = "$y$"` and After $c$';
+    const regions = scanMathRegions(text);
+    expect(regions).toHaveLength(2);
+    expect(regions.map((r) => r.source)).toEqual(['a', 'c']);
+  });
+
+  it('handles longer backtick runs for inline code', () => {
+    expect(scanMathRegions('`` `$z$` ``')).toEqual([]);
+  });
+
+  it('skips dollars in inline code inside list items', () => {
+    const text = '- `${pkgs.system}` and `$a + $b`';
+    expect(scanMathRegions(text)).toEqual([]);
+  });
+});

--- a/src/math/math-scanner.ts
+++ b/src/math/math-scanner.ts
@@ -15,6 +15,11 @@ type FencedCodeBlock = {
   isMathFence: boolean;
 };
 
+type InlineCodeSpan = {
+  startPos: number;
+  endPos: number;
+};
+
 const MATH_FENCE_LANGUAGES = new Set(['math', 'latex', 'tex']);
 
 /**
@@ -28,10 +33,12 @@ const MATH_FENCE_LANGUAGES = new Set(['math', 'latex', 'tex']);
  */
 export function scanMathRegions(text: string): MathRegion[] {
   const fencedBlocks = scanFencedCodeBlocks(text);
+  const inlineCodeSpans = scanInlineCodeSpans(text);
   const regions: MathRegion[] = [];
   let i = 0;
   const n = text.length;
   let fenceIndex = 0;
+  let inlineCodeIndex = 0;
 
   while (i < n) {
     while (fenceIndex < fencedBlocks.length && fencedBlocks[fenceIndex].endPos <= i) {
@@ -40,6 +47,15 @@ export function scanMathRegions(text: string): MathRegion[] {
     const activeFence = fencedBlocks[fenceIndex];
     if (activeFence && i >= activeFence.startPos && i < activeFence.endPos) {
       i = activeFence.endPos;
+      continue;
+    }
+
+    while (inlineCodeIndex < inlineCodeSpans.length && inlineCodeSpans[inlineCodeIndex].endPos <= i) {
+      inlineCodeIndex++;
+    }
+    const activeInlineCode = inlineCodeSpans[inlineCodeIndex];
+    if (activeInlineCode && i >= activeInlineCode.startPos && i < activeInlineCode.endPos) {
+      i = activeInlineCode.endPos;
       continue;
     }
 
@@ -227,6 +243,63 @@ function scanFencedCodeBlocks(text: string): FencedCodeBlock[] {
   }
 
   return blocks;
+}
+
+/**
+ * Scans for CommonMark inline code spans delimited by backtick runs.
+ * Opening and closing runs must be the same length or the closing run may be longer.
+ */
+function scanInlineCodeSpans(text: string): InlineCodeSpan[] {
+  const spans: InlineCodeSpan[] = [];
+  let i = 0;
+
+  while (i < text.length) {
+    if (text[i] !== '`') {
+      i++;
+      continue;
+    }
+
+    let openLen = 0;
+    let j = i;
+    while (j < text.length && text[j] === '`' && openLen < 32) {
+      openLen++;
+      j++;
+    }
+    if (openLen === 0) {
+      i++;
+      continue;
+    }
+
+    let k = j;
+    let closedAt = -1;
+    while (k < text.length) {
+      if (text[k] !== '`') {
+        k++;
+        continue;
+      }
+      let closeLen = 0;
+      let m = k;
+      while (m < text.length && text[m] === '`' && closeLen < 32) {
+        closeLen++;
+        m++;
+      }
+      if (closeLen >= openLen) {
+        closedAt = m;
+        break;
+      }
+      k = m;
+    }
+
+    if (closedAt === -1) {
+      i = j;
+      continue;
+    }
+
+    spans.push({ startPos: i, endPos: closedAt });
+    i = closedAt;
+  }
+
+  return spans;
 }
 
 function parseOpeningFence(

--- a/src/mermaid/__tests__/editor-width.test.ts
+++ b/src/mermaid/__tests__/editor-width.test.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+import { bucketWidthForCache, estimateEditorContentWidthPx } from '../editor-width';
+
+vi.mock('../../config', () => ({
+  config: {
+    mermaid: {
+      maxWidthColumns: vi.fn(() => 0),
+    },
+  },
+}));
+
+import { config } from '../../config';
+
+function createEditor(visibleRanges: vscode.Range[], lines: string[] = ['x'.repeat(120)]): vscode.TextEditor {
+  const document = {
+    lineAt: (line: number) => ({ text: lines[line] ?? '' }),
+  };
+  return {
+    visibleRanges,
+    document,
+  } as unknown as vscode.TextEditor;
+}
+
+describe('estimateEditorContentWidthPx', () => {
+  beforeEach(() => {
+    vi.mocked(config.mermaid.maxWidthColumns).mockReturnValue(0);
+    vi.spyOn(vscode.workspace, 'getConfiguration').mockReturnValue({
+      get: (key: string, defaultValue?: number) => {
+        if (key === 'fontSize') return 14;
+        if (key === 'lineHeight') return 0;
+        return defaultValue;
+      },
+    } as vscode.WorkspaceConfiguration);
+  });
+
+  it('estimates width from visible viewport columns', () => {
+    const editor = createEditor([new vscode.Range(0, 0, 0, 150)]);
+    const width = estimateEditorContentWidthPx(editor);
+    expect(width).toBeGreaterThanOrEqual(320);
+    expect(width).toBeLessThanOrEqual(Math.round(14 * 0.6 * 500));
+  });
+
+  it('uses configured maxWidthColumns override when set', () => {
+    vi.mocked(config.mermaid.maxWidthColumns).mockReturnValue(100);
+    const editor = createEditor([new vscode.Range(0, 0, 0, 150)]);
+    expect(estimateEditorContentWidthPx(editor)).toBe(Math.round(14 * 0.6 * 100));
+  });
+
+  it('enforces a minimum width floor', () => {
+    const editor = createEditor([new vscode.Range(0, 0, 0, 10)]);
+    expect(estimateEditorContentWidthPx(editor)).toBeGreaterThanOrEqual(320);
+  });
+});
+
+describe('bucketWidthForCache', () => {
+  it('rounds width to 50px buckets', () => {
+    expect(bucketWidthForCache(124)).toBe(100);
+    expect(bucketWidthForCache(126)).toBe(150);
+  });
+});

--- a/src/mermaid/editor-width.ts
+++ b/src/mermaid/editor-width.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+import { config } from '../config';
+
+const CHAR_WIDTH_RATIO = 0.6;
+const DEFAULT_COLUMNS = 120;
+const MIN_MAX_WIDTH_PX = 320;
+const MAX_MAX_WIDTH_PX = 4096;
+const WIDTH_BUCKET_PX = 50;
+
+/**
+ * Estimates the editor content area width in pixels for scaling Mermaid diagrams.
+ * Uses visible viewport columns when no explicit setting override is configured.
+ */
+export function estimateEditorContentWidthPx(editor: vscode.TextEditor): number {
+  const editorConfig = vscode.workspace.getConfiguration('editor');
+  const fontSize = editorConfig.get<number>('fontSize', 14);
+  const configuredColumns = config.mermaid.maxWidthColumns();
+  const columns = configuredColumns > 0 ? configuredColumns : estimateVisibleColumns(editor);
+  const width = Math.round(fontSize * CHAR_WIDTH_RATIO * columns);
+  return Math.min(MAX_MAX_WIDTH_PX, Math.max(MIN_MAX_WIDTH_PX, width));
+}
+
+/** Buckets width for render cache keys so minor viewport changes do not churn the cache. */
+export function bucketWidthForCache(widthPx: number): number {
+  return Math.round(widthPx / WIDTH_BUCKET_PX) * WIDTH_BUCKET_PX;
+}
+
+function estimateVisibleColumns(editor: vscode.TextEditor): number {
+  const visibleRanges = editor.visibleRanges ?? [];
+  if (visibleRanges.length === 0) {
+    return DEFAULT_COLUMNS;
+  }
+
+  let maxViewportColumns = 0;
+  for (const range of editor.visibleRanges) {
+    const lineColumns = range.end.character - range.start.character;
+    if (lineColumns > maxViewportColumns) {
+      maxViewportColumns = lineColumns;
+    }
+  }
+
+  if (maxViewportColumns >= 40) {
+    return maxViewportColumns;
+  }
+
+  let maxLineEnd = 0;
+  for (const range of editor.visibleRanges) {
+    for (let line = range.start.line; line <= range.end.line; line++) {
+      maxLineEnd = Math.max(maxLineEnd, editor.document.lineAt(line).text.length);
+    }
+  }
+
+  return Math.max(maxViewportColumns, maxLineEnd, DEFAULT_COLUMNS);
+}

--- a/src/mermaid/mermaid-renderer.ts
+++ b/src/mermaid/mermaid-renderer.ts
@@ -178,14 +178,16 @@ export async function renderMermaidSvg(
   const numLines = options.numLines || 5;
   const height = options.height || ((numLines + 2) * lineHeight);
 
-  // Estimate the editor viewport width to cap only genuinely oversized diagrams.
-  // Monospace character width ≈ 0.6× font size. We use 200 columns as a generous
-  // full-width estimate so normal diagrams (flowcharts, gantt, sequence) render at
-  // their natural size, and only truly huge charts (> ~1680px at 14px font) are
-  // constrained. Using fewer columns caused normal charts to be squished (#50).
-  const maxWidth = Math.round(fontSize * 0.6 * 200);
+  const maxWidth = options.maxWidth ?? Math.round(fontSize * 0.6 * 200);
 
   return getMermaidDecoration(source, darkMode, height, options.fontFamily, maxWidth);
+}
+
+/**
+ * Clears the Mermaid decoration render cache so diagrams re-render at new dimensions.
+ */
+export function clearMermaidDecorationCache(): void {
+  decorationCache.clear();
 }
 
 // Re-export utilities for use by other modules

--- a/src/mermaid/types.ts
+++ b/src/mermaid/types.ts
@@ -6,6 +6,7 @@ export type MermaidRenderOptions = {
   fontFamily?: string;
   height?: number; // Height in pixels based on line count
   numLines?: number; // Number of lines in the code block
+  maxWidth?: number; // Maximum width in pixels for scaling oversized diagrams
 };
 
 /**

--- a/src/parser/__tests__/parser-code-block.test.ts
+++ b/src/parser/__tests__/parser-code-block.test.ts
@@ -736,5 +736,41 @@ describe('MarkdownParser - Code Blocks', () => {
       expect(languageDec).toBeDefined();
     });
   });
+
+  describe('indented code blocks inside ordered lists (#80)', () => {
+    it('should style multiple indented fences without bleeding into list text', () => {
+      const markdown = [
+        '1. Test scene:',
+        '',
+        '    ```sh',
+        '    npm start -- --scene=$SCENE_NAME --web',
+        '    ```',
+        '',
+        '    i.e.',
+        '',
+        '    ```sh',
+        '    npm start -- --scene=pdf --web',
+        '    ```',
+        '',
+        '2. Trigger a render locally (using case directory):',
+        '',
+        '    ```sh',
+        '    npm start -- --scene=$SCENE_NAME --case=$PATH_TO_CASE --output=$PATH_TO_OUTPUT_PNG',
+        '    ```',
+      ].join('\n');
+
+      const result = parser.extractDecorations(markdown);
+      const codeBlocks = result.filter((d) => d.type === 'codeBlock');
+      expect(codeBlocks.length).toBe(3);
+
+      const listMarkerDecs = result.filter((d) => d.type === 'listMarker' || d.type === 'listItem');
+      listMarkerDecs.forEach((dec) => {
+        codeBlocks.forEach((block) => {
+          const overlaps = dec.startPos < block.endPos && dec.endPos > block.startPos;
+          expect(overlaps).toBe(false);
+        });
+      });
+    });
+  });
 });
 

--- a/src/parser/code-blocks.ts
+++ b/src/parser/code-blocks.ts
@@ -2,6 +2,14 @@ import type { Code } from 'mdast';
 import { addScope, hasValidPosition } from './common';
 import type { DecorationRange, MermaidBlock, ScopeRange } from './types';
 
+type FenceMatch = {
+  fenceStart: number;
+  fenceChar: string;
+  fenceLength: number;
+};
+
+const MAX_FENCE_SEARCH_LINES = 20;
+
 export function processCodeBlock(
   node: Code,
   text: string,
@@ -15,93 +23,13 @@ export function processCodeBlock(
 
   const codeStart = node.position!.start.offset!;
   const codeEnd = node.position!.end.offset!;
-  let fenceStart = codeStart;
-  let fenceChar: string | null = null;
-  let fenceLength = 0;
-  const lineStart = text.lastIndexOf('\n', codeStart - 1) + 1;
-
-  for (let pos = lineStart; pos < codeStart && pos < text.length; pos++) {
-    const char = text[pos];
-    if (char === '`' || char === '~') {
-      let count = 1;
-      let checkPos = pos + 1;
-      while (checkPos < text.length && text[checkPos] === char && count < 20) {
-        count++;
-        checkPos++;
-      }
-      if (count >= 3) {
-        fenceStart = pos;
-        fenceChar = char;
-        fenceLength = count;
-        break;
-      }
-    }
+  const openingFence = findOpeningFence(text, codeStart);
+  if (!openingFence) {
+    return;
   }
 
-  if (!fenceChar) {
-    for (let pos = codeStart; pos < Math.min(codeStart + 20, text.length); pos++) {
-      const char = text[pos];
-      if (char === '`' || char === '~') {
-        let count = 1;
-        let checkPos = pos + 1;
-        while (checkPos < text.length && text[checkPos] === char && count < 20) {
-          count++;
-          checkPos++;
-        }
-        if (count >= 3) {
-          fenceStart = pos;
-          fenceChar = char;
-          fenceLength = count;
-          break;
-        }
-      }
-    }
-  }
-
-  if (!fenceChar || fenceLength < 3) {
-    const fallbackFence = text.indexOf('```', codeStart - 10);
-    if (fallbackFence === -1 || fallbackFence > codeStart) {
-      return;
-    }
-    fenceStart = fallbackFence;
-    fenceChar = '`';
-    fenceLength = 3;
-  }
-
-  let closingFence = -1;
-  const closingLineStart = text.lastIndexOf('\n', codeEnd - 1) + 1;
-  for (let pos = codeEnd - 1; pos >= closingLineStart && pos >= fenceStart + fenceLength; pos--) {
-    if (text[pos] === fenceChar) {
-      let count = 1;
-      let checkPos = pos - 1;
-      while (checkPos >= 0 && text[checkPos] === fenceChar && count < 20) {
-        count++;
-        checkPos--;
-      }
-      if (count >= fenceLength) {
-        closingFence = pos - count + 1;
-        break;
-      }
-    }
-  }
-
-  if (closingFence === -1) {
-    for (let pos = codeEnd; pos < Math.min(codeEnd + 20, text.length); pos++) {
-      if (text[pos] === fenceChar) {
-        let count = 1;
-        let checkPos = pos + 1;
-        while (checkPos < text.length && text[checkPos] === fenceChar && count < 20) {
-          count++;
-          checkPos++;
-        }
-        if (count >= fenceLength) {
-          closingFence = pos;
-          break;
-        }
-      }
-    }
-  }
-
+  const { fenceStart, fenceChar, fenceLength } = openingFence;
+  const closingFence = findClosingFence(text, codeEnd, fenceChar, fenceLength, fenceStart);
   if (closingFence === -1 || closingFence <= fenceStart) {
     return;
   }
@@ -208,4 +136,173 @@ export function processCodeBlock(
       numLines,
     });
   }
+}
+
+function findOpeningFence(text: string, codeStart: number): FenceMatch | null {
+  const codeLineStart = text.lastIndexOf('\n', codeStart - 1) + 1;
+
+  const sameLineFence = findFenceInRange(text, codeLineStart, codeStart);
+  if (sameLineFence) {
+    return sameLineFence;
+  }
+
+  const forwardFence = findFenceInRange(text, codeStart, Math.min(codeStart + 20, text.length));
+  if (forwardFence) {
+    return forwardFence;
+  }
+
+  let lineStart = codeLineStart;
+  for (let line = 0; line < MAX_FENCE_SEARCH_LINES && lineStart > 0; line++) {
+    const prevLineEnd = lineStart - 1;
+    lineStart = text.lastIndexOf('\n', prevLineEnd - 1) + 1;
+    const prevLineFence = findFenceInRange(text, lineStart, prevLineEnd + 1);
+    if (prevLineFence) {
+      return prevLineFence;
+    }
+  }
+
+  const fallbackFence = text.indexOf('```', Math.max(0, codeStart - 10));
+  if (fallbackFence !== -1 && fallbackFence <= codeStart) {
+    return {
+      fenceStart: fallbackFence,
+      fenceChar: '`',
+      fenceLength: 3,
+    };
+  }
+
+  return null;
+}
+
+function findClosingFence(
+  text: string,
+  codeEnd: number,
+  fenceChar: string,
+  fenceLength: number,
+  fenceStart: number,
+): number {
+  const closingLineStart = text.lastIndexOf('\n', codeEnd - 1) + 1;
+  const sameLineClosing = findClosingFenceInRange(
+    text,
+    closingLineStart,
+    codeEnd,
+    fenceChar,
+    fenceLength,
+    fenceStart,
+    true,
+  );
+  if (sameLineClosing !== -1) {
+    return sameLineClosing;
+  }
+
+  const forwardClosing = findClosingFenceInRange(
+    text,
+    codeEnd,
+    Math.min(codeEnd + 20, text.length),
+    fenceChar,
+    fenceLength,
+    fenceStart,
+    false,
+  );
+  if (forwardClosing !== -1) {
+    return forwardClosing;
+  }
+
+  let lineEnd = text.indexOf('\n', codeEnd);
+  if (lineEnd === -1) {
+    lineEnd = text.length;
+  }
+
+  for (let line = 0; line < MAX_FENCE_SEARCH_LINES && lineEnd < text.length; line++) {
+    const nextLineStart = lineEnd + 1;
+    if (nextLineStart >= text.length) {
+      break;
+    }
+    const nextLineEnd = text.indexOf('\n', nextLineStart);
+    const lineLimit = nextLineEnd === -1 ? text.length : nextLineEnd;
+    const closing = findClosingFenceInRange(
+      text,
+      nextLineStart,
+      lineLimit,
+      fenceChar,
+      fenceLength,
+      fenceStart,
+      false,
+    );
+    if (closing !== -1) {
+      return closing;
+    }
+    if (nextLineEnd === -1) {
+      break;
+    }
+    lineEnd = nextLineEnd;
+  }
+
+  return -1;
+}
+
+function findFenceInRange(text: string, start: number, end: number): FenceMatch | null {
+  for (let pos = start; pos < end && pos < text.length; pos++) {
+    const char = text[pos];
+    if (char !== '`' && char !== '~') {
+      continue;
+    }
+    let count = 1;
+    let checkPos = pos + 1;
+    while (checkPos < text.length && text[checkPos] === char && count < 20) {
+      count++;
+      checkPos++;
+    }
+    if (count >= 3) {
+      return {
+        fenceStart: pos,
+        fenceChar: char,
+        fenceLength: count,
+      };
+    }
+  }
+  return null;
+}
+
+function findClosingFenceInRange(
+  text: string,
+  start: number,
+  end: number,
+  fenceChar: string,
+  fenceLength: number,
+  fenceStart: number,
+  searchBackward: boolean,
+): number {
+  if (searchBackward) {
+    for (let pos = end - 1; pos >= start && pos >= fenceStart + fenceLength; pos--) {
+      if (text[pos] !== fenceChar) {
+        continue;
+      }
+      let count = 1;
+      let checkPos = pos - 1;
+      while (checkPos >= 0 && text[checkPos] === fenceChar && count < 20) {
+        count++;
+        checkPos--;
+      }
+      if (count >= fenceLength) {
+        return pos - count + 1;
+      }
+    }
+    return -1;
+  }
+
+  for (let pos = start; pos < end && pos < text.length; pos++) {
+    if (text[pos] !== fenceChar) {
+      continue;
+    }
+    let count = 1;
+    let checkPos = pos + 1;
+    while (checkPos < text.length && text[checkPos] === fenceChar && count < 20) {
+      count++;
+      checkPos++;
+    }
+    if (count >= fenceLength) {
+      return pos;
+    }
+  }
+  return -1;
 }

--- a/src/registration/__tests__/register-event-handlers.test.ts
+++ b/src/registration/__tests__/register-event-handlers.test.ts
@@ -5,6 +5,8 @@ import { registerEventHandlers } from '../register-event-handlers';
 describe('registerEventHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vscode.window.onDidChangeTextEditorVisibleRanges = vi.fn(() => ({ dispose: vi.fn() })) as any;
+    vscode.window.onDidChangeWindowState = vi.fn(() => ({ dispose: vi.fn() })) as any;
   });
 
   it('registers editor, workspace, and theme listeners', () => {
@@ -19,6 +21,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      clearMermaidDecorationCache: vi.fn(),
     };
     const linkClickHandler = {
       setEnabled: vi.fn(),
@@ -26,7 +29,7 @@ describe('registerEventHandlers', () => {
 
     const disposables = registerEventHandlers(decorator as any, linkClickHandler as any);
 
-    expect(disposables).toHaveLength(6);
+    expect(disposables).toHaveLength(8);
   });
 
   it('routes editor and workspace events to the decorator', () => {
@@ -78,6 +81,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      clearMermaidDecorationCache: vi.fn(),
     };
 
     registerEventHandlers(decorator as any, { setEnabled: vi.fn() } as any);
@@ -126,6 +130,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      clearMermaidDecorationCache: vi.fn(),
     };
     const linkClickHandler = {
       setEnabled: vi.fn(),

--- a/src/registration/register-event-handlers.ts
+++ b/src/registration/register-event-handlers.ts
@@ -3,6 +3,19 @@ import { config } from '../config';
 import { Decorator } from '../decorator';
 import { LinkClickHandler } from '../link-click-handler';
 
+const MERMAID_VIEWPORT_REFRESH_MS = 150;
+let mermaidViewportRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+
+function scheduleMermaidViewportRefresh(decorator: Decorator): void {
+  if (mermaidViewportRefreshTimer) {
+    clearTimeout(mermaidViewportRefreshTimer);
+  }
+  mermaidViewportRefreshTimer = setTimeout(() => {
+    mermaidViewportRefreshTimer = undefined;
+    decorator.clearMermaidDecorationCache();
+  }, MERMAID_VIEWPORT_REFRESH_MS);
+}
+
 export function registerEventHandlers(
   decorator: Decorator,
   linkClickHandler: LinkClickHandler
@@ -35,6 +48,10 @@ export function registerEventHandlers(
         decorator.recreateGhostFaintDecorationType();
       }
 
+      if (event.affectsConfiguration('markdownInlineEditor.decorations.ghostLinks.collapse')) {
+        decorator.updateDecorationsForSelection();
+      }
+
       if (event.affectsConfiguration('markdownInlineEditor.decorations.frontmatterDelimiterOpacity')) {
         decorator.recreateFrontmatterDelimiterDecorationType();
       }
@@ -58,6 +75,21 @@ export function registerEventHandlers(
       if (event.affectsConfiguration('editor.fontSize') || event.affectsConfiguration('editor.lineHeight')) {
         decorator.clearMathDecorationCache();
       }
+
+      if (
+        event.affectsConfiguration('markdownInlineEditor.mermaid.maxWidthColumns') ||
+        event.affectsConfiguration('editor.fontSize')
+      ) {
+        decorator.clearMermaidDecorationCache();
+      }
+    }),
+    vscode.window.onDidChangeTextEditorVisibleRanges((event) => {
+      if (event.textEditor === vscode.window.activeTextEditor) {
+        scheduleMermaidViewportRefresh(decorator);
+      }
+    }),
+    vscode.window.onDidChangeWindowState(() => {
+      scheduleMermaidViewportRefresh(decorator);
     }),
     vscode.window.onDidChangeActiveColorTheme(() => {
       decorator.recreateColorDependentTypes();

--- a/src/test/e2e/suite/extension.test.ts
+++ b/src/test/e2e/suite/extension.test.ts
@@ -12,22 +12,53 @@ const EXTENSION_ID = 'CodeSmith.markdown-inline-editor-vscode';
 // We cannot import those types directly (tsconfig.e2e.json rootDir constraint),
 // so we declare the minimal shape needed here.
 type DR = { type: string; startPos: number; endPos: number; url?: string };
-type PE = { text: string; decorations: DR[] };
-type ParseCacheExport = { get(doc: vscode.TextDocument): PE };
 type DecoratorExport = {
   isEnabled(): boolean;
   activeEditor: vscode.TextEditor | undefined;
   onApply: ((nonEmptyTypeCount: number) => void) | undefined;
+  /** True when the active editor document URI is a diff/merge view. */
+  isActiveEditorDiffView(): boolean;
 };
+type MathRegionExport = { startPos: number; endPos: number; source: string; displayMode: boolean };
+type ScopeRangeExport = { startPos: number; endPos: number; kind?: string };
+type MermaidBlockExport = { startPos: number; endPos: number; source: string; numLines: number };
+type PE = {
+  text: string;
+  decorations: DR[];
+  mathRegions: MathRegionExport[];
+  scopes: ScopeRangeExport[];
+  mermaidBlocks: MermaidBlockExport[];
+};
+type ParseCacheExport = { get(doc: vscode.TextDocument): PE };
 type SvgProcessorExport = {
   processSvg: (svgString: string, height: number, maxWidth?: number) => string;
 };
-type ExtExports = { parseCache?: ParseCacheExport; decorator?: DecoratorExport; svgProcessor?: SvgProcessorExport };
+type TestUtilsExport = {
+  scanMathRegions: (text: string) => MathRegionExport[];
+  estimateEditorContentWidthPx: (editor: vscode.TextEditor) => number;
+  bucketWidthForCache: (widthPx: number) => number;
+  isDiffLikeUri: (uri: vscode.Uri) => boolean;
+  filterDecorationsForEditor: (
+    editor: vscode.TextEditor,
+    decorations: DR[],
+    scopes: Array<{ startPos: number; endPos: number; range: vscode.Range; kind?: string }>,
+    originalText: string,
+    rangeFactory: (startPos: number, endPos: number, originalText: string) => vscode.Range | null,
+    options?: { ghostLinksCollapse?: boolean },
+  ) => Map<string, unknown[]>;
+};
+type ExtExports = {
+  parseCache?: ParseCacheExport;
+  decorator?: DecoratorExport;
+  svgProcessor?: SvgProcessorExport;
+  testUtils?: TestUtilsExport;
+};
 
 /** Populated in suiteSetup from ext.exports. */
 let cache: ParseCacheExport | undefined;
 let decoratorApi: DecoratorExport | undefined;
 let svgProcessor: SvgProcessorExport | undefined;
+let testUtils: TestUtilsExport | undefined;
 
 suite('Extension E2E', () => {
   suiteSetup(async () => {
@@ -39,6 +70,7 @@ suite('Extension E2E', () => {
     cache = exports?.parseCache;
     decoratorApi = exports?.decorator;
     svgProcessor = exports?.svgProcessor;
+    testUtils = exports?.testUtils;
   });
 
   test('extension is present', () => {
@@ -1154,10 +1186,323 @@ suite('Extension E2E', () => {
       'Expected heading1 decoration in cache after inserting "# Heading"'
     );
   });
+
+  // ── Regressions for PR #129 (issues #80, #92, #95, #108, #114) ───────────
+
+  test('#92 — parse: $ inside inline backtick code does not produce math regions', async () => {
+    assert.ok(cache, 'parseCache not available from ext.exports');
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: [
+        '- `${pkgs.system}` boilerplate',
+        '- `$100$` literal dollars',
+        '- `const s = "$x$"` inside code',
+      ].join('\n'),
+    });
+    await vscode.window.showTextDocument(doc);
+    await delay(400);
+    const entry = cache.get(doc);
+    assert.strictEqual(
+      entry.mathRegions.length,
+      0,
+      `Expected no math regions for $ inside inline code, got: ${entry.mathRegions.map(r => r.source).join(', ')}`
+    );
+  });
+
+  test('#92 — testUtils.scanMathRegions skips $ inside inline code but keeps outside math', () => {
+    assert.ok(testUtils, 'testUtils not available from ext.exports');
+    const text = 'Before $a$ and `const b = "$y$"` and After $c$';
+    const regions = testUtils.scanMathRegions(text);
+    assert.strictEqual(regions.length, 2, 'Expected two math regions outside inline code');
+    assert.deepStrictEqual(
+      regions.map(r => r.source),
+      ['a', 'c'],
+      'Math sources should exclude inline-code $ spans'
+    );
+  });
+
+  test('#92 — parse: inline and block math still detected when not inside code', async () => {
+    assert.ok(cache, 'parseCache not available from ext.exports');
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: 'Inline $E=mc^2$ and block:\n\n$$\n\\sum_{i=1}^n i\n$$',
+    });
+    await vscode.window.showTextDocument(doc);
+    await delay(400);
+    const entry = cache.get(doc);
+    assert.ok(entry.mathRegions.length >= 2, 'Expected inline and block math regions');
+    assert.ok(
+      entry.mathRegions.some(r => !r.displayMode && r.source.includes('E=mc')),
+      'Expected inline math region'
+    );
+    assert.ok(
+      entry.mathRegions.some(r => r.displayMode),
+      'Expected block math region'
+    );
+  });
+
+  test('#80 — parse: indented code blocks inside ordered lists produce three codeBlock decorations', async () => {
+    assert.ok(cache, 'parseCache not available from ext.exports');
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: issue80Markdown(),
+    });
+    await vscode.window.showTextDocument(doc);
+    await delay(500);
+    const entry = cache.get(doc);
+    const codeBlocks = entry.decorations.filter(d => d.type === 'codeBlock');
+    assert.strictEqual(
+      codeBlocks.length,
+      3,
+      `Expected 3 codeBlock decorations for nested list fences, got ${codeBlocks.length}`
+    );
+
+    const listMarkers = entry.decorations.filter(
+      d => d.type === 'listItem' || d.type === 'orderedListItem' || d.type === 'listMarker'
+    );
+    for (const marker of listMarkers) {
+      for (const block of codeBlocks) {
+        assert.ok(
+          !rangesOverlap(marker.startPos, marker.endPos, block.startPos, block.endPos),
+          'List marker decoration must not overlap a code block decoration'
+        );
+      }
+    }
+  });
+
+  test('#80 — parse: bold/italic inside indented list code fences are not decorated', async () => {
+    assert.ok(cache, 'parseCache not available from ext.exports');
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: issue80Markdown(),
+    });
+    await vscode.window.showTextDocument(doc);
+    await delay(500);
+    const entry = cache.get(doc);
+    const inlineBold = entry.decorations.filter(d => d.type === 'bold' || d.type === 'boldItalic');
+    for (const bold of inlineBold) {
+      const slice = entry.text.slice(bold.startPos, bold.endPos);
+      assert.ok(
+        !slice.includes('npm start') && !slice.includes('SCENE_NAME'),
+        `Inline bold must not appear inside list code blocks, got "${slice}"`
+      );
+    }
+  });
+
+  test('#95 — testUtils.isDiffLikeUri distinguishes file vs git diff URIs', () => {
+    assert.ok(testUtils, 'testUtils not available from ext.exports');
+    assert.strictEqual(testUtils.isDiffLikeUri(vscode.Uri.file('/tmp/test.md')), false);
+    assert.strictEqual(testUtils.isDiffLikeUri(vscode.Uri.parse('git:/path/to/file.md')), true);
+    assert.strictEqual(testUtils.isDiffLikeUri(vscode.Uri.parse('vscode-diff:/path/to/file.md')), true);
+    assert.strictEqual(testUtils.isDiffLikeUri(vscode.Uri.parse('vscode-merge:/path/to/file.md')), true);
+  });
+
+  test('#95 — active markdown editor is not treated as diff view in split layout', async () => {
+    assert.ok(decoratorApi, 'decorator not available from ext.exports');
+    const docA = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: '# File A\n\n**bold** text',
+    });
+    const docB = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: '# File B\n\n_italic_ text',
+    });
+
+    await vscode.window.showTextDocument(docA, { viewColumn: vscode.ViewColumn.One });
+    await delay(250);
+    await vscode.window.showTextDocument(docB, { viewColumn: vscode.ViewColumn.Two });
+    await delay(250);
+    await vscode.window.showTextDocument(docA, { viewColumn: vscode.ViewColumn.One });
+    await delay(300);
+
+    assert.strictEqual(
+      decoratorApi.isActiveEditorDiffView(),
+      false,
+      'Focused markdown file must not be treated as a diff view (#95)'
+    );
+    assert.strictEqual(
+      testUtils?.isDiffLikeUri(docA.uri),
+      false,
+      'Untitled/file markdown URI must not be diff-like'
+    );
+
+    let nonEmptyTypeCount = 0;
+    decoratorApi.onApply = (count) => { nonEmptyTypeCount += count; };
+    try {
+      await vscode.commands.executeCommand('cursorMove', { to: 'right' });
+      await delay(300);
+      assert.ok(
+        nonEmptyTypeCount > 0,
+        'Decorations must still render on focused markdown when another editor is open beside it'
+      );
+    } finally {
+      decoratorApi.onApply = undefined;
+    }
+  });
+
+  test('#108 — diagram wider than viewport maxWidth is scaled down (processSvg)', () => {
+    assert.ok(svgProcessor, 'svgProcessor not available from ext.exports');
+    const viewportMaxWidth = Math.round(14 * 0.6 * 150); // ~150 cols at 14px font
+    const svg = makeSvgFixture(1400, 400);
+    const result = svgProcessor.processSvg(svg, 400, viewportMaxWidth);
+    const width = parseSvgWidth(result);
+    assert.strictEqual(
+      width,
+      viewportMaxWidth,
+      `Diagram wider than viewport must scale to ${viewportMaxWidth}px, got ${width}px`
+    );
+  });
+
+  test('#108 — estimateEditorContentWidthPx returns a bounded width for the active editor', async () => {
+    assert.ok(testUtils, 'testUtils not available from ext.exports');
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: '# Width test\n\n' + 'x'.repeat(200),
+    });
+    await vscode.window.showTextDocument(doc);
+    await delay(400);
+    const editor = vscode.window.activeTextEditor;
+    assert.ok(editor, 'Expected an active editor');
+    const width = testUtils.estimateEditorContentWidthPx(editor);
+    assert.ok(width >= 320, `Expected width floor >= 320px, got ${width}`);
+    assert.ok(width <= 4096, `Expected width ceiling <= 4096px, got ${width}`);
+    const bucket = testUtils.bucketWidthForCache(width);
+    assert.ok(bucket > 0, 'Width bucket must be positive');
+  });
+
+  test('#108 — wide flowchart LR mermaid block decorates without error', async () => {
+    const doc = await vscode.workspace.openTextDocument({
+      language: 'markdown',
+      content: [
+        '# Wide Mermaid',
+        '',
+        '```mermaid',
+        'flowchart LR',
+        '  A[Start] --> B[Process]',
+        '  B --> C[More]',
+        '  C --> D[Even More]',
+        '  D --> E[End]',
+        '```',
+      ].join('\n'),
+    });
+    await vscode.window.showTextDocument(doc);
+    await delay(800);
+    assert.strictEqual(doc.languageId, 'markdown');
+    assert.ok(cache, 'parseCache not available from ext.exports');
+    const entry = cache.get(doc);
+    assert.ok(
+      entry.mermaidBlocks.length >= 1,
+      'Expected at least one mermaid block in parse cache'
+    );
+  });
+
+  test('#114 — ghostLinks.collapse applies hide instead of ghostFaint for link syntax on active line', async () => {
+    assert.ok(cache && testUtils, 'parseCache/testUtils not available from ext.exports');
+    const text = '[FAQ](https://example.com/faq) and [Reviews](https://example.com/reviews)';
+    const doc = await vscode.workspace.openTextDocument({ language: 'markdown', content: text });
+    await vscode.window.showTextDocument(doc);
+    await delay(400);
+
+    const editor = vscode.window.activeTextEditor;
+    assert.ok(editor, 'Expected active editor');
+    editor.selection = new vscode.Selection(new vscode.Position(0, text.length), new vscode.Position(0, text.length));
+
+    const entry = cache.get(doc);
+    const scopeEntries = buildScopeEntries(doc, entry.scopes);
+    const filtered = testUtils.filterDecorationsForEditor(
+      editor,
+      entry.decorations,
+      scopeEntries,
+      entry.text,
+      (startPos, endPos) =>
+        new vscode.Range(doc.positionAt(startPos), doc.positionAt(endPos)),
+      { ghostLinksCollapse: true },
+    );
+
+    const linkDecorations = entry.decorations.filter(d => d.type === 'link');
+    assert.ok(linkDecorations.length >= 2, 'Expected link decorations in parse output');
+
+    const hideRanges = (filtered.get('hide') as unknown[] | undefined) ?? [];
+    const ghostFaintRanges = (filtered.get('ghostFaint') as unknown[] | undefined) ?? [];
+    assert.ok(hideRanges.length > 0, 'Collapsed ghost links should use hide decorations');
+    assert.strictEqual(
+      ghostFaintRanges.length,
+      0,
+      'Collapsed ghost links should not route link syntax to ghostFaint'
+    );
+  });
+
+  test('#114 — enabling ghostLinks.collapse via settings does not break decoration rendering', async () => {
+    assert.ok(decoratorApi, 'decorator not available from ext.exports');
+    const configSection = vscode.workspace.getConfiguration('markdownInlineEditor');
+    await configSection.update('decorations.ghostLinks.collapse', true, vscode.ConfigurationTarget.Global);
+    try {
+      const doc = await vscode.workspace.openTextDocument({
+        language: 'markdown',
+        content: '[One](https://a.test/one) [Two](https://a.test/two) [Three](https://a.test/three)',
+      });
+      await vscode.window.showTextDocument(doc);
+      await delay(400);
+
+      let nonEmptyTypeCount = 0;
+      decoratorApi.onApply = (count) => { nonEmptyTypeCount += count; };
+      try {
+        await vscode.commands.executeCommand('cursorMove', { to: 'right' });
+        await delay(300);
+        assert.ok(
+          nonEmptyTypeCount > 0,
+          'Decorator must still apply ranges when ghostLinks.collapse is enabled'
+        );
+      } finally {
+        decoratorApi.onApply = undefined;
+      }
+    } finally {
+      await configSection.update('decorations.ghostLinks.collapse', undefined, vscode.ConfigurationTarget.Global);
+    }
+  });
 });
 
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function rangesOverlap(aStart: number, aEnd: number, bStart: number, bEnd: number): boolean {
+  return aStart < bEnd && aEnd > bStart;
+}
+
+function buildScopeEntries(
+  doc: vscode.TextDocument,
+  scopes: ScopeRangeExport[],
+): Array<{ startPos: number; endPos: number; range: vscode.Range; kind?: string }> {
+  return scopes.map((scope) => ({
+    startPos: scope.startPos,
+    endPos: scope.endPos,
+    kind: scope.kind,
+    range: new vscode.Range(doc.positionAt(scope.startPos), doc.positionAt(scope.endPos)),
+  }));
+}
+
+/** Repro markdown from GitHub issue #80. */
+function issue80Markdown(): string {
+  return [
+    '1. Test scene:',
+    '',
+    '    ```sh',
+    '    npm start -- --scene=$SCENE_NAME --web',
+    '    ```',
+    '',
+    '    i.e.',
+    '',
+    '    ```sh',
+    '    npm start -- --scene=pdf --web',
+    '    ```',
+    '',
+    '2. Trigger a render locally (using case directory):',
+    '',
+    '    ```sh',
+    '    npm start -- --scene=$SCENE_NAME --case=$PATH_TO_CASE --output=$PATH_TO_OUTPUT_PNG',
+    '    ```',
+  ].join('\n');
 }
 
 /**


### PR DESCRIPTION
## Summary

- **#95** — Scope diff detection to the active editor URI so markdown decorations stay enabled when an unrelated diff preview is open in a split pane.
- **#92** — Skip `$`/`$$` math scanning inside inline backtick code spans (e.g. `` `${FOO}` ``).
- **#80** — Detect indented opening/closing fences for code blocks nested inside ordered list items.
- **#108** — Scale Mermaid diagrams to estimated editor viewport width; re-render on resize via debounced visible-range/window-state handlers. New setting: `markdownInlineEditor.mermaid.maxWidthColumns`.
- **#114** — Add opt-in `markdownInlineEditor.decorations.ghostLinks.collapse` to fully hide (zero-width) link URL syntax on ghost lines instead of showing faint markers.