### PR TITLE
feat(tables): add preview-style table rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Your files stay 100% standard Markdown. This extension uses editor decorations �
 
 - **No preview pane needed:** headings, emphasis, links, images, lists, code, **GFM tables**, math, and Mermaid render inline where you write.
 - **Rendered -> Ghost -> Raw syntax shadowing:** Markdown markers stay out of the way until you need them, then fade in on the active line or fully reveal for precise edits.
-- **GFM tables:** pipe characters and cell text are drawn as an aligned grid; place the cursor anywhere in the table to reveal raw `|` syntax for editing.
+- **GFM tables:** pipe characters and cell text are drawn as an aligned grid; place the cursor anywhere in the table to reveal raw `|` syntax for editing. Set `tables.style` to `preview` for a preview-pane look instead — pipes hidden, columns laid out as fixed-width boxes that line up whatever the font does with full-width (CJK) characters, bold header and thin rules.
 - **Inline Mermaid and LaTeX math:** render `` ```mermaid `` diagrams, `$...$`, `$$...$$`, and `` ```math `` blocks directly in the editor.
 - **Interactive Markdown:** click task list checkboxes to toggle them, hover links to see targets, and hover images to preview them.
 - **Safe for real workflows:** files remain plain Markdown, and diffs stay raw by default for Git, merge editor, and Copilot inline review contexts.
@@ -144,6 +144,15 @@ Everything works out of the box. If you want to tune the experience, open Settin
   - Style GitHub-style `@user` / `#123`; optional clickable targets when forge context is available. See [Mentions & references][feat-mentions-references].
 - **Emoji shortcodes** (`emojis.enabled`, default `true`)
   - Disable if you prefer seeing `:shortcode:` text.
+- **Table style** (`tables.style`, default `grid`)
+  - `grid` is the character-grid look (`│` pipes and a dashed separator row), which relies on the font rendering full-width characters at exactly the configured ratio.
+  - `preview` hides the `|` pipes and lays every cell out as a fixed-width box, so columns line up no matter how your font renders full-width characters. Adds a bold header, a rule under the header row and thin row separators. Worth switching on for documents that mix CJK and ASCII text, or if you use a proportional font.
+- **CJK column width** (`tables.cjkWidthRatio`, default `2`)
+  - How wide a full-width character is compared to an ASCII one when sizing columns. Raise it if CJK text is clipped, lower it if columns look too wide.
+- **Maximum column width** (`tables.maxColumnWidth`, default `48`)
+  - Caps runaway columns in `preview` style; longer text is clipped in the rendered view and shown in full when the cursor enters the table.
+- **Table row separators** (`tables.rowSeparators`, default `true`)
+  - Turn off for a table without horizontal lines between rows.
 - **Syntax colors** (`colors.heading1` … `colors.checkbox`, 15 options including `inlineCodeBackground`)
   - Optional hex overrides (e.g. `#e06c75`) for headings, links, list markers, inline code, inline code background, emphasis, blockquote, image, horizontal rule, checkbox. Unset or invalid values use theme-derived defaults (for headings, unset keeps the editor’s markdown heading syntax colors rather than forcing a single foreground). See [Customizable Syntax Colors][feat-customizable-syntax-colors].
 

--- a/docs/features/done/preview-style-tables.md
+++ b/docs/features/done/preview-style-tables.md
@@ -1,0 +1,117 @@
+---
+status: DONE
+updateDate: 2026-07-27
+priority: Medium Priority
+---
+
+# Preview-Style Tables
+
+## Overview
+
+An opt-in table rendering mode that mirrors the markdown preview pane: the `|` pipes are hidden, every cell is laid out as a fixed-width CSS box, the header row is bold and the separator row becomes a single horizontal rule.
+
+The existing `grid` rendering pads cell text with non-breaking spaces to a width measured from the source. That only lines up when the editor font renders a full-width glyph at exactly the assumed ratio, so tables mixing CJK and ASCII text come out ragged, as do proportional fonts. Sizing each cell in CSS removes the font from the alignment equation: every cell in a column gets the same width, so the grid is straight whatever the font does, and the width estimate only decides whether the text fits.
+
+Selected with `markdownInlineEditor.tables.style`; `grid` remains the default.
+
+## Implementation
+
+- `tables.style` (`preview` | `grid`, default `grid`) picks the rendering path in `parser/core.ts` `processTable()`
+- Preview path emits:
+  - `tablePipe` / `tableSeparatorPipe` with an empty replacement, hiding the pipes
+  - `tableCell` carrying the plain cell text plus `boxWidth`, `cellAlign`, `isHeaderCell` and `drawRowSeparator`
+  - one `tableRule` decoration replacing the whole separator row
+- `decorator/visibility-model.ts` turns those into per-range `renderOptions.before` styling: `width: <n>ch`, `display: inline-block`, `box-sizing: border-box`, `padding: 0 1ch`, `overflow: hidden`, `text-align`, and an optional bottom border. This is the same CSS-injection-through-`textDecoration` technique already used by the checkbox and mermaid decorations
+- Column width is `max(cell widths) + 1ch padding either side`, clamped by `tables.maxColumnWidth` (default 48)
+- `tables.cjkWidthRatio` (default 2) replaces the previous hard-coded "2 columns plus a 25% fudge" estimate. The width scan also now recognises the fullwidth forms block (U+FF00–FF60), so `（`, `）` and friends count as two columns
+- `tables.rowSeparators` (default true) draws the thin rule under each data row
+- Column alignment (`:---`, `:---:`, `---:`) is applied with `text-align`, so it holds even when a cell contains hidden markup
+- Table settings invalidate the parse cache in `registration/register-event-handlers.ts`, since they change parser output rather than just styling
+- Cursor-inside-table still reveals the whole block as raw markdown, unchanged
+
+## Acceptance Criteria
+
+```gherkin
+Feature: Preview-style tables
+
+  Background:
+    Given markdownInlineEditor.tables.style is "preview"
+
+  Scenario: Pipes are hidden
+    When I open a document containing a GFM table
+    Then no | characters are drawn
+    And the separator row is drawn as a single horizontal rule
+
+  Scenario: Columns line up regardless of content width
+    When a column contains both ASCII and CJK cells
+    Then every cell in that column is rendered at the same width
+
+  Scenario: Header styling
+    When a table has a header row
+    Then the header cells are bold
+    And the header cells have no bottom border of their own
+
+  Scenario: Column alignment
+    When a column is declared with ---:
+    Then its cells are right-aligned
+
+  Scenario: Long cells are capped
+    Given tables.maxColumnWidth is 10
+    When a cell contains 80 characters
+    Then the column box is 12 character widths wide
+
+  Scenario: Raw reveal is unaffected
+    When I place the cursor inside the table
+    Then the whole table is shown as raw markdown
+
+  Scenario: Grid style is untouched
+    Given markdownInlineEditor.tables.style is "grid"
+    When I open a document containing a GFM table
+    Then pipes are rendered as │
+    And the separator row is rendered as runs of -
+```
+
+## Notes
+
+- Cells cannot wrap. An editor line maps to one visual line, so text past `maxColumnWidth` is clipped in the rendered view; moving the cursor into the table shows it in full. Wide tables are best viewed with `editor.wordWrap` off, since a wrapped row breaks the run of cell boxes ([issue #76](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/76))
+- `tables.cjkWidthRatio` overlaps with [PR #116](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/pull/116), which proposed the same setting for the grid path
+- Addresses the alignment half of [issue #21](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/21) and [issue #41](https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/issues/41): in preview style, hidden markup and proportional fonts no longer skew columns
+
+## Examples
+
+Source:
+
+```markdown
+| 回  | 日時       | テーマ             | 講師                     |
+| --- | ---------- | ------------------ | ------------------------ |
+| 1   | 2026/7/10  | イントロダクション | 栗田 駿一郎（HGPI）      |
+| 2   | 2026/8/14  | アジェンダ設定(1)  | 市川 衛（武蔵大学）      |
+```
+
+`grid` style — pipes drawn, alignment depends on the font:
+
+```text
+│ 回  │ 日時       │ テーマ             │ 講師                │
+│-----│------------│--------------------│---------------------│
+│ 1   │ 2026/7/10  │ イントロダクション │ 栗田 駿一郎（HGPI） │
+```
+
+`preview` style — pipes hidden, boxes sized in `ch`, header bold and ruled:
+
+```text
+回   日時        テーマ               講師
+──────────────────────────────────────────────────────────
+1    2026/7/10   イントロダクション   栗田 駿一郎（HGPI）
+2    2026/8/14   アジェンダ設定(1)    市川 衛（武蔵大学）
+```
+
+Settings:
+
+```json
+{
+  "markdownInlineEditor.tables.style": "preview",
+  "markdownInlineEditor.tables.cjkWidthRatio": 2,
+  "markdownInlineEditor.tables.maxColumnWidth": 48,
+  "markdownInlineEditor.tables.rowSeparators": true
+}
+```

--- a/docs/features/todo.md
+++ b/docs/features/todo.md
@@ -83,6 +83,8 @@ Enable or disable decorations per file instead of globally; state persists acros
 
 Keep table columns aligned when cells contain formatted text (bold, code, italic). Hidden markup changes rendered width and currently breaks alignment.
 
+**Solved for `preview` table style** — see [`done/preview-style-tables.md`](./done/preview-style-tables.md). Sizing each cell as a fixed-width CSS box sidesteps text measurement entirely, so hidden markup no longer changes the column width, and `:---` / `:---:` / `---:` are applied with `text-align`. Still open for the default `grid` style, which pads with spaces and therefore depends on font metrics.
+
 - Measure rendered width of formatted cells (VS Code text measurement or font metrics); adjust column spacing to preserve alignment.
 - Handle mixed cells, multiple formatting in one cell, and left/center/right alignment.
 - Depends on tables feature; 1–2 weeks; feasibility moderate, usefulness high.

--- a/package.json
+++ b/package.json
@@ -148,6 +148,42 @@
           "description": "Highlight when the source marker number differs from the computed number",
           "markdownDescription": "When ordered list auto-numbering is on, use the warning color for the displayed marker when the number in the source text does not match the computed number (for example all lines use `1.` but the view shows 1., 2., 3.)."
         },
+        "markdownInlineEditor.tables.style": {
+          "type": "string",
+          "enum": [
+            "preview",
+            "grid"
+          ],
+          "enumDescriptions": [
+            "Render tables like the markdown preview: no pipes, aligned columns, bold header, thin rules",
+            "Render tables as a character grid using │ pipes and a dashed separator row"
+          ],
+          "default": "grid",
+          "description": "How GFM tables are rendered inline",
+          "markdownDescription": "How GFM tables are rendered inline.\n\n- `preview`: hides the `|` pipes and lays every cell out as a fixed-width box, so columns line up regardless of the editor font. Adds a bold header, a rule under the header row and thin row separators. Recommended for documents that mix CJK and ASCII text.\n- `grid`: the original character-grid look, which relies on the font rendering full-width characters at exactly the configured ratio."
+        },
+        "markdownInlineEditor.tables.cjkWidthRatio": {
+          "type": "number",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 3,
+          "description": "Display width of a CJK character relative to an ASCII character",
+          "markdownDescription": "Display width of a full-width (CJK) character relative to an ASCII character, used to size table columns. `2` matches fonts where a full-width glyph is exactly two half-width glyphs (for example BIZ UDGothic, UDEV Gothic, PlemolJP). Increase it if CJK text is clipped, decrease it if columns are too wide."
+        },
+        "markdownInlineEditor.tables.maxColumnWidth": {
+          "type": "number",
+          "default": 48,
+          "minimum": 3,
+          "maximum": 200,
+          "description": "Maximum table column width, in character widths",
+          "markdownDescription": "Maximum width of a single table column, in character widths. Longer cell content is clipped in the rendered view; move the cursor into the table to see the full raw text. Only used when `#markdownInlineEditor.tables.style#` is `preview`."
+        },
+        "markdownInlineEditor.tables.rowSeparators": {
+          "type": "boolean",
+          "default": true,
+          "description": "Draw a thin rule under every table row",
+          "markdownDescription": "Draw a thin rule under every table row, like the markdown preview. Only used when `#markdownInlineEditor.tables.style#` is `preview`."
+        },
         "markdownInlineEditor.mentions.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,45 @@ export const config = {
         .get<boolean>('orderedLists.warnWhenSourceNumberDiffers', true);
     },
   },
+  tables: {
+    /**
+     * `grid` (the default) keeps the box-drawing look: │ pipes and a dashed separator row.
+     * `preview` renders tables like the markdown preview instead: pipes hidden, cells laid
+     * out as fixed-width CSS boxes, bold header and horizontal rules.
+     */
+    style(): 'preview' | 'grid' {
+      const value = vscode.workspace
+        .getConfiguration(SECTION)
+        .get<string>('tables.style', 'grid');
+      return value === 'preview' ? 'preview' : 'grid';
+    },
+    /**
+     * Display width of a CJK (full-width) character relative to an ASCII character, used to
+     * estimate how wide a column box must be. 2 matches fonts where a full-width glyph is
+     * exactly two half-width glyphs.
+     */
+    cjkWidthRatio(): number {
+      const value = vscode.workspace
+        .getConfiguration(SECTION)
+        .get<number>('tables.cjkWidthRatio', 2);
+      if (typeof value !== 'number' || !Number.isFinite(value)) return 2;
+      return Math.min(3, Math.max(1, value));
+    },
+    /** Upper bound for a column box, in character widths. Longer cells are clipped. */
+    maxColumnWidth(): number {
+      const value = vscode.workspace
+        .getConfiguration(SECTION)
+        .get<number>('tables.maxColumnWidth', 48);
+      if (typeof value !== 'number' || !Number.isFinite(value)) return 48;
+      return Math.min(200, Math.max(3, Math.floor(value)));
+    },
+    /** Draw a thin rule under every data row (preview style only). */
+    rowSeparators(): boolean {
+      return vscode.workspace
+        .getConfiguration(SECTION)
+        .get<boolean>('tables.rowSeparators', true);
+    },
+  },
   mentions: {
     /** If set, overrides GitHub context: true = force links on, false = force off. Unset = use git remote auto-detect. */
     linksEnabled(): boolean | undefined {

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -613,6 +613,24 @@ export function TableSeparatorDashDecorationType() {
 }
 
 /**
+ * Creates a decoration type for the separator row of a preview-style table.
+ *
+ * Hides the `|---|---|` line and renders a single horizontal rule spanning the table,
+ * which doubles as the underline of the header row. The rule width is supplied per range
+ * via `renderOptions.before`.
+ *
+ * @returns {vscode.TextEditorDecorationType} A decoration type for the table rule
+ */
+export function TableRuleDecorationType() {
+  return window.createTextEditorDecorationType({
+    textDecoration: 'none; display: none;',
+    before: {
+      contentText: '',
+    },
+  });
+}
+
+/**
  * Creates a decoration type for table cell content.
  *
  * Hides the original cell text (with irregular spacing) and renders

--- a/src/decorator/__tests__/config-tables.test.ts
+++ b/src/decorator/__tests__/config-tables.test.ts
@@ -1,0 +1,86 @@
+import { workspace } from '../../test/__mocks__/vscode';
+import { config } from '../../config';
+
+const mockGet = vi.fn();
+const mockGetConfiguration = vi.fn().mockReturnValue({ get: mockGet });
+
+(workspace as any).getConfiguration = mockGetConfiguration;
+
+/** Makes the mocked configuration return `value` for `key` and the default for everything else. */
+function stub(key: string, value: unknown) {
+  mockGet.mockImplementation((requested: string, defaultValue: unknown) =>
+    requested === key ? value : defaultValue
+  );
+}
+
+describe('config.tables', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockGet.mockImplementation((_key: string, defaultValue: unknown) => defaultValue);
+  });
+
+  describe('style', () => {
+    it('defaults to grid', () => {
+      expect(config.tables.style()).toBe('grid');
+    });
+
+    it('returns preview when configured', () => {
+      stub('tables.style', 'preview');
+      expect(config.tables.style()).toBe('preview');
+    });
+
+    it('falls back to grid for an unknown value', () => {
+      stub('tables.style', 'nonsense');
+      expect(config.tables.style()).toBe('grid');
+    });
+  });
+
+  describe('cjkWidthRatio', () => {
+    it('defaults to 2', () => {
+      expect(config.tables.cjkWidthRatio()).toBe(2);
+    });
+
+    it('accepts a fractional ratio', () => {
+      stub('tables.cjkWidthRatio', 1.8);
+      expect(config.tables.cjkWidthRatio()).toBe(1.8);
+    });
+
+    it('clamps out-of-range values', () => {
+      stub('tables.cjkWidthRatio', 0.1);
+      expect(config.tables.cjkWidthRatio()).toBe(1);
+      stub('tables.cjkWidthRatio', 99);
+      expect(config.tables.cjkWidthRatio()).toBe(3);
+    });
+
+    it('falls back to 2 for a non-numeric value', () => {
+      stub('tables.cjkWidthRatio', 'wide');
+      expect(config.tables.cjkWidthRatio()).toBe(2);
+    });
+  });
+
+  describe('maxColumnWidth', () => {
+    it('defaults to 48', () => {
+      expect(config.tables.maxColumnWidth()).toBe(48);
+    });
+
+    it('clamps and floors the configured value', () => {
+      stub('tables.maxColumnWidth', 20.7);
+      expect(config.tables.maxColumnWidth()).toBe(20);
+      stub('tables.maxColumnWidth', 1);
+      expect(config.tables.maxColumnWidth()).toBe(3);
+      stub('tables.maxColumnWidth', 5000);
+      expect(config.tables.maxColumnWidth()).toBe(200);
+    });
+  });
+
+  describe('rowSeparators', () => {
+    it('defaults to true', () => {
+      expect(config.tables.rowSeparators()).toBe(true);
+    });
+
+    it('returns false when disabled', () => {
+      stub('tables.rowSeparators', false);
+      expect(config.tables.rowSeparators()).toBe(false);
+    });
+  });
+});

--- a/src/decorator/__tests__/visibility-model.test.ts
+++ b/src/decorator/__tests__/visibility-model.test.ts
@@ -153,6 +153,91 @@ describe('table decoration rendering', () => {
   });
 });
 
+describe('preview-style table layout', () => {
+  function renderCell(decoration: Partial<DecorationRange>) {
+    const text = '| A |\nother';
+    const decs: DecorationRange[] = [
+      { startPos: 2, endPos: 3, type: 'tableCell', replacement: 'A', ...decoration } as any,
+    ];
+    const editor = makeEditor(text, 1, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    return (result.get('tableCell') as any[])[0].renderOptions?.before;
+  }
+
+  it('lays the cell out as a fixed-width box', () => {
+    const before = renderCell({ boxWidth: 8, cellAlign: 'left' });
+    expect(before.contentText).toBe('A');
+    expect(before.textDecoration).toContain('display: inline-block');
+    expect(before.textDecoration).toContain('box-sizing: border-box');
+    expect(before.textDecoration).toContain('width: 8ch');
+    expect(before.textDecoration).toContain('overflow: hidden');
+    expect(before.textDecoration).toContain('text-align: left');
+  });
+
+  it('applies the column alignment', () => {
+    expect(renderCell({ boxWidth: 8, cellAlign: 'right' }).textDecoration)
+      .toContain('text-align: right');
+    expect(renderCell({ boxWidth: 8, cellAlign: 'center' }).textDecoration)
+      .toContain('text-align: center');
+  });
+
+  it('renders header cells bold', () => {
+    expect(renderCell({ boxWidth: 8, isHeaderCell: true }).fontWeight).toBe('bold');
+    expect(renderCell({ boxWidth: 8 }).fontWeight).toBeUndefined();
+  });
+
+  it('draws a bottom border only when a row separator is requested', () => {
+    const withSeparator = renderCell({ boxWidth: 8, drawRowSeparator: true });
+    expect(withSeparator.textDecoration).toContain('border-bottom-width: 1px');
+    expect(withSeparator.borderColor).toBeDefined();
+
+    const withoutSeparator = renderCell({ boxWidth: 8 });
+    expect(withoutSeparator.textDecoration).not.toContain('border-bottom-width');
+    expect(withoutSeparator.borderColor).toBeUndefined();
+  });
+
+  it('keeps the cell style text-decoration as the base value', () => {
+    const before = renderCell({
+      boxWidth: 8,
+      cellStyle: { textDecoration: 'line-through' },
+    });
+    expect(before.textDecoration.startsWith('line-through;')).toBe(true);
+    expect(before.textDecoration).toContain('display: inline-block');
+  });
+
+  it('leaves grid-style cells untouched when no box width is given', () => {
+    const before = renderCell({ replacement: ' A ' });
+    expect(before.contentText).toBe(' A ');
+    expect(before.textDecoration).toBeUndefined();
+  });
+
+  it('renders the separator row as a rule spanning the table', () => {
+    const text = '|---|\nother';
+    const decs: DecorationRange[] = [
+      { startPos: 0, endPos: 5, type: 'tableRule', replacement: '', boxWidth: 16 } as any,
+    ];
+    const editor = makeEditor(text, 1, 0);
+    const result = filterDecorationsForEditor(
+      editor as any,
+      decs,
+      [],
+      text,
+      (s, e, t) => simpleRangeFactory(s, e, t),
+    );
+    const before = (result.get('tableRule') as any[])[0].renderOptions?.before;
+    expect(before.contentText).toBe('');
+    expect(before.textDecoration).toContain('width: 16ch');
+    expect(before.textDecoration).toContain('border-bottom-width: 1px');
+    expect(before.borderColor).toBeDefined();
+  });
+});
+
 describe('selection overlay for codeBlock/frontmatter', () => {
   it('adds selectionOverlay when non-empty selection covers a codeBlock', () => {
     const text = '```\ncode\n```';

--- a/src/decorator/decoration-type-registry.ts
+++ b/src/decorator/decoration-type-registry.ts
@@ -34,6 +34,7 @@ import {
   TablePipeDecorationType,
   TableSeparatorPipeDecorationType,
   TableSeparatorDashDecorationType,
+  TableRuleDecorationType,
   TableCellDecorationType,
 } from '../decorations';
 import type { DecorationType } from '../parser';
@@ -95,6 +96,7 @@ export class DecorationTypeRegistry {
   private tablePipeDecorationType!: TextEditorDecorationType;
   private tableSeparatorPipeDecorationType!: TextEditorDecorationType;
   private tableSeparatorDashDecorationType!: TextEditorDecorationType;
+  private tableRuleDecorationType!: TextEditorDecorationType;
   private tableCellDecorationType!: TextEditorDecorationType;
 
   private decorationTypeMap = new Map<DecorationType, TextEditorDecorationType>();
@@ -137,6 +139,7 @@ export class DecorationTypeRegistry {
     this.tablePipeDecorationType = TablePipeDecorationType();
     this.tableSeparatorPipeDecorationType = TableSeparatorPipeDecorationType();
     this.tableSeparatorDashDecorationType = TableSeparatorDashDecorationType();
+    this.tableRuleDecorationType = TableRuleDecorationType();
     this.tableCellDecorationType = TableCellDecorationType();
 
     this.decorationTypeMap = new Map<DecorationType, TextEditorDecorationType>([
@@ -172,6 +175,7 @@ export class DecorationTypeRegistry {
       ['tablePipe', this.tablePipeDecorationType],
       ['tableSeparatorPipe', this.tableSeparatorPipeDecorationType],
       ['tableSeparatorDash', this.tableSeparatorDashDecorationType],
+      ['tableRule', this.tableRuleDecorationType],
       ['tableCell', this.tableCellDecorationType],
       // Keep this last so it is applied after backgrounds.
       ['selectionOverlay', this.selectionOverlayDecorationType],

--- a/src/decorator/editor-decoration-applier.ts
+++ b/src/decorator/editor-decoration-applier.ts
@@ -74,7 +74,8 @@ export function applyFilteredDecorations(
   onApply?: (nonEmptyTypeCount: number) => void
 ): void {
   const renderOptionsTypes = new Set<DecorationType>([
-    'emoji', 'orderedListItem', 'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableCell',
+    'emoji', 'orderedListItem', 'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash',
+    'tableRule', 'tableCell',
   ]);
 
   for (const [type, decorationType] of decorationTypes.getMap().entries()) {

--- a/src/decorator/visibility-model.ts
+++ b/src/decorator/visibility-model.ts
@@ -1,5 +1,6 @@
 import { Range, ThemeColor, type DecorationOptions, type Position, type TextEditor } from 'vscode';
 import type { DecorationRange, DecorationType } from '../parser';
+import { CELL_PADDING_CH } from '../parser/tables';
 import { isMarkerDecorationType } from './decoration-categories';
 
 export type ScopeEntry = {
@@ -66,7 +67,7 @@ export function filterDecorationsForEditor(
 
   // Table decoration types that use per-range replacement rendering
   const tableTypes = new Set<DecorationType>([
-    'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableCell',
+    'tablePipe', 'tableSeparatorPipe', 'tableSeparatorDash', 'tableRule', 'tableCell',
   ]);
 
   // For table blocks, if cursor/selection is on ANY line in the table,
@@ -214,6 +215,11 @@ export function filterDecorationsForEditor(
           if (decoration.cellStyle.fontStyle) beforeOpts.fontStyle = decoration.cellStyle.fontStyle;
           if (decoration.cellStyle.textDecoration) beforeOpts.textDecoration = decoration.cellStyle.textDecoration;
         }
+        if (decoration.type === 'tableRule') {
+          applyTableRuleStyle(beforeOpts, decoration);
+        } else if (decoration.type === 'tableCell' && decoration.boxWidth !== undefined) {
+          applyTableCellBoxStyle(beforeOpts, decoration);
+        }
         ranges.push({
           range,
           renderOptions: {
@@ -255,6 +261,76 @@ export function filterDecorationsForEditor(
   }
 
   return filtered;
+}
+
+/** Theme color used for the header rule and the row separators. */
+function tableRuleColor(): ThemeColor {
+  return new ThemeColor('editorWidget.border');
+}
+
+/**
+ * Lays a preview-style table cell out as a fixed-width box.
+ *
+ * Giving every cell in a column the same CSS width is what makes the columns line up:
+ * the width estimate only decides whether the text fits, never whether the grid is
+ * straight, so a font that renders full-width glyphs at an unexpected ratio no longer
+ * skews the table.
+ *
+ * @param {Record<string, unknown>} beforeOpts - Render options being built for the cell
+ * @param {DecorationRange} decoration - The cell decoration carrying box width and alignment
+ */
+function applyTableCellBoxStyle(
+  beforeOpts: Record<string, unknown>,
+  decoration: DecorationRange
+): void {
+  const styles = [
+    // The first entry is the text-decoration value itself; the rest are extra
+    // declarations injected into the same rule.
+    (beforeOpts.textDecoration as string | undefined) ?? 'none',
+    'display: inline-block',
+    'box-sizing: border-box',
+    `width: ${decoration.boxWidth}ch`,
+    `padding: 0 ${CELL_PADDING_CH}ch`,
+    'overflow: hidden',
+    'white-space: pre',
+    'vertical-align: bottom',
+    `text-align: ${decoration.cellAlign ?? 'left'}`,
+  ];
+
+  if (decoration.drawRowSeparator) {
+    styles.push('border-bottom-width: 1px', 'border-bottom-style: solid');
+    beforeOpts.borderColor = tableRuleColor();
+  }
+
+  beforeOpts.textDecoration = `${styles.join('; ')};`;
+  if (decoration.isHeaderCell) {
+    beforeOpts.fontWeight = 'bold';
+  }
+}
+
+/**
+ * Renders the separator row as a single horizontal rule spanning the table, which also
+ * serves as the underline of the header row.
+ *
+ * @param {Record<string, unknown>} beforeOpts - Render options being built for the rule
+ * @param {DecorationRange} decoration - The rule decoration carrying the table width
+ */
+function applyTableRuleStyle(
+  beforeOpts: Record<string, unknown>,
+  decoration: DecorationRange
+): void {
+  const width = decoration.boxWidth !== undefined ? `${decoration.boxWidth}ch` : '100%';
+  beforeOpts.textDecoration = [
+    'none',
+    'display: inline-block',
+    'box-sizing: border-box',
+    `width: ${width}`,
+    'height: 0.6em',
+    'vertical-align: middle',
+    'border-bottom-width: 1px',
+    'border-bottom-style: solid',
+  ].join('; ') + ';';
+  beforeOpts.borderColor = tableRuleColor();
 }
 
 function collectRawRanges(selectedRanges: Range[], scopes: ScopeEntry[]): Range[] {

--- a/src/parser/__tests__/parser-table.test.ts
+++ b/src/parser/__tests__/parser-table.test.ts
@@ -1,4 +1,5 @@
 import { MarkdownParser, DecorationRange } from '../../parser';
+import { workspace } from '../../test/__mocks__/vscode';
 
 describe('MarkdownParser - Tables', () => {
   let parser: MarkdownParser;
@@ -11,102 +12,200 @@ describe('MarkdownParser - Tables', () => {
     return decs.filter((d) => d.type === type);
   }
 
-  describe('basic table rendering', () => {
-    it('should create tablePipe decorations for pipe characters', () => {
+  /** Runs `fn` with the given `markdownInlineEditor.*` settings in effect. */
+  function withConfig<T>(overrides: Record<string, unknown>, fn: () => T): T {
+    const original = (workspace as any).getConfiguration;
+    (workspace as any).getConfiguration = () => ({
+      get: (key: string, defaultValue: unknown) =>
+        key in overrides ? overrides[key] : defaultValue,
+    });
+    try {
+      return fn();
+    } finally {
+      (workspace as any).getConfiguration = original;
+    }
+  }
+
+  /**
+   * Turns on preview style for the enclosing describe block. Tables render in `grid`
+   * style by default, so every preview expectation has to opt in.
+   */
+  function usePreviewStyle(extraOverrides: Record<string, unknown> = {}) {
+    let original: unknown;
+    beforeEach(() => {
+      original = (workspace as any).getConfiguration;
+      const overrides = { 'tables.style': 'preview', ...extraOverrides };
+      (workspace as any).getConfiguration = () => ({
+        get: (key: string, defaultValue: unknown) =>
+          key in overrides ? overrides[key] : defaultValue,
+      });
+    });
+    afterEach(() => {
+      (workspace as any).getConfiguration = original;
+    });
+  }
+
+  describe('basic table rendering (preview style)', () => {
+    usePreviewStyle();
+
+    it('should hide pipe characters in preview style', () => {
       const md = '| A | B |\n|---|---|\n| 1 | 2 |';
       const result = parser.extractDecorations(md);
       const pipes = byType(result, 'tablePipe');
-      // 3 rows × 3 pipes each = 9, minus separator pipes
+      // Header and data row, 3 pipes each; separator pipes are reported separately
       expect(pipes.length).toBeGreaterThanOrEqual(6);
       pipes.forEach((p) => {
-        expect(p.replacement).toBe('\u2502');
+        expect(p.replacement).toBe('');
       });
     });
 
-    it('should create tableCell decorations with padded replacement', () => {
+    it('should create tableCell decorations with unpadded text and a box width', () => {
       const md = '| Name | Age |\n|------|-----|\n| Jo   | 5   |';
       const result = parser.extractDecorations(md);
       const cells = byType(result, 'tableCell');
       expect(cells.length).toBeGreaterThanOrEqual(4);
       cells.forEach((c) => {
         expect(c.replacement).toBeDefined();
-        // Each cell should start and end with non-breaking space
-        expect(c.replacement!.startsWith('\u00A0')).toBe(true);
-        expect(c.replacement!.endsWith('\u00A0')).toBe(true);
+        // Preview style lays cells out with CSS, so no padding is baked into the text
+        expect(c.replacement).toBe(c.replacement!.trim());
+        expect(c.boxWidth).toBeGreaterThan(0);
       });
     });
 
-    it('should create separator decorations', () => {
+    it('should give every cell in a column the same box width', () => {
+      const md = '| Name | Age |\n|------|-----|\n| Jo   | 5   |';
+      const result = parser.extractDecorations(md);
+      const cells = byType(result, 'tableCell');
+      const nameColumn = cells.filter((c) => ['Name', 'Jo'].includes(c.replacement!));
+      expect(nameColumn).toHaveLength(2);
+      expect(nameColumn[0].boxWidth).toBe(nameColumn[1].boxWidth);
+    });
+
+    it('should mark header cells and put row separators on data rows only', () => {
       const md = '| A | B |\n|---|---|\n| 1 | 2 |';
       const result = parser.extractDecorations(md);
-      const sepPipes = byType(result, 'tableSeparatorPipe');
-      const sepDashes = byType(result, 'tableSeparatorDash');
-      expect(sepPipes.length).toBeGreaterThanOrEqual(3);
-      expect(sepDashes.length).toBeGreaterThanOrEqual(2);
+      const cells = byType(result, 'tableCell');
+      const headerCells = cells.filter((c) => c.isHeaderCell);
+      const dataCells = cells.filter((c) => !c.isHeaderCell);
+      expect(headerCells).toHaveLength(2);
+      expect(dataCells).toHaveLength(2);
+      expect(headerCells.every((c) => c.drawRowSeparator !== true)).toBe(true);
+      expect(dataCells.every((c) => c.drawRowSeparator === true)).toBe(true);
+    });
+
+    it('should replace the separator row with a single rule spanning the table', () => {
+      const md = '| A | B |\n|---|---|\n| 1 | 2 |';
+      const result = parser.extractDecorations(md);
+      const rules = byType(result, 'tableRule');
+      expect(rules).toHaveLength(1);
+      expect(byType(result, 'tableSeparatorDash')).toHaveLength(0);
+      expect(byType(result, 'tableSeparatorPipe')).toHaveLength(0);
+
+      const headerWidth = byType(result, 'tableCell')
+        .filter((c) => c.isHeaderCell)
+        .reduce((total, c) => total + c.boxWidth!, 0);
+      expect(rules[0].boxWidth).toBe(headerWidth);
+    });
+
+    it('should omit row separators when they are disabled', () => {
+      const md = '| A | B |\n|---|---|\n| 1 | 2 |';
+      const result = withConfig({ 'tables.style': 'preview', 'tables.rowSeparators': false }, () =>
+        parser.extractDecorations(md)
+      );
+      expect(byType(result, 'tableCell').every((c) => c.drawRowSeparator !== true)).toBe(true);
+      // The header rule is independent of the row separators
+      expect(byType(result, 'tableRule')).toHaveLength(1);
     });
   });
 
-  describe('column alignment', () => {
+  describe('column alignment (preview style)', () => {
+    usePreviewStyle();
+
     const alignedTable = [
       '| Left | Center | Right |',
       '|:-----|:------:|------:|',
       '| a    |   b    |     c |',
     ].join('\n');
 
-    it('should left-align cells by default (pad right)', () => {
+    it('should left-align cells by default', () => {
       const md = '| Foo | Bar |\n|-----|-----|\n| x   | y   |';
       const result = parser.extractDecorations(md);
-      const cells = byType(result, 'tableCell');
-      // Default alignment: content starts after one NBSP
-      const dataCell = cells.find((c) => c.replacement!.includes('x'));
+      const dataCell = byType(result, 'tableCell').find((c) => c.replacement === 'x');
       expect(dataCell).toBeDefined();
-      // Left-aligned: starts with single NBSP then content
-      expect(dataCell!.replacement!.indexOf('x')).toBe(1);
+      expect(dataCell!.cellAlign).toBe('left');
     });
 
     it('should right-align cells when column uses ---:', () => {
       const result = parser.extractDecorations(alignedTable);
-      const cells = byType(result, 'tableCell');
-      // Find a data row cell for the right-aligned column (column index 2, content "c")
-      const rightCell = cells.find((c) => c.replacement!.includes('c'));
+      const rightCell = byType(result, 'tableCell').find((c) => c.replacement === 'c');
       expect(rightCell).toBeDefined();
-      // Right-aligned: content should end with single NBSP
-      expect(rightCell!.replacement!.endsWith('c\u00A0')).toBe(true);
-      // Should have leading padding
-      const leadingSpaces = rightCell!.replacement!.length - rightCell!.replacement!.trimStart().length;
-      expect(leadingSpaces).toBeGreaterThanOrEqual(1);
+      expect(rightCell!.cellAlign).toBe('right');
     });
 
     it('should center-align cells when column uses :---:', () => {
       const result = parser.extractDecorations(alignedTable);
-      const cells = byType(result, 'tableCell');
-      // Find a data row cell for the center-aligned column (column index 1, content "b")
-      const centerCell = cells.find((c) => c.replacement!.includes('b'));
+      const centerCell = byType(result, 'tableCell').find((c) => c.replacement === 'b');
       expect(centerCell).toBeDefined();
-      // Center-aligned: should have padding on both sides
-      const content = centerCell!.replacement!;
-      const trimmed = content.replace(/\u00A0/g, '').trim();
-      const beforeContent = content.indexOf(trimmed);
-      const afterContent = content.length - beforeContent - trimmed.length;
-      // Both sides should have at least 1 char of padding
-      expect(beforeContent).toBeGreaterThanOrEqual(1);
-      expect(afterContent).toBeGreaterThanOrEqual(1);
+      expect(centerCell!.cellAlign).toBe('center');
     });
   });
 
-  describe('CJK wide characters', () => {
-    it('should account for CJK double-width in column padding', () => {
-      const md = '| Name | CJK  |\n|------|------|\n| AB   | \u4F60\u597D   |';
+  describe('CJK wide characters (preview style)', () => {
+    usePreviewStyle();
+
+    it('should size a CJK column using the configured width ratio', () => {
+      const md = '| Name | CJK  |\n|------|------|\n| AB   | 你好   |';
       const result = parser.extractDecorations(md);
       const cells = byType(result, 'tableCell');
-      // All cells should have replacement text
       cells.forEach((c) => {
         expect(c.replacement).toBeDefined();
+      });
+      // Header "CJK" is 3 wide, the data cell is 2 CJK chars = 4 wide at ratio 2,
+      // so the column box is 4 plus one character of padding on either side.
+      const cjkColumn = cells.filter((c) => ['CJK', '你好'].includes(c.replacement!));
+      expect(cjkColumn).toHaveLength(2);
+      cjkColumn.forEach((c) => expect(c.boxWidth).toBe(6));
+    });
+
+    it('should treat fullwidth parentheses as wide characters', () => {
+      // Fullwidth （） are common in Japanese text and are two cells wide
+      const md = '| A |\n|---|\n| （x） |';
+      const result = parser.extractDecorations(md);
+      const dataCell = byType(result, 'tableCell').find((c) => !c.isHeaderCell);
+      expect(dataCell).toBeDefined();
+      // 2 fullwidth parens (2 each) + "x" = 5, plus padding on either side
+      expect(dataCell!.boxWidth).toBe(7);
+    });
+
+    it('should honour a custom cjkWidthRatio', () => {
+      const md = '| A |\n|---|\n| あいう |';
+      const wide = withConfig({ 'tables.style': 'preview', 'tables.cjkWidthRatio': 2 }, () =>
+        parser.extractDecorations(md)
+      );
+      const narrow = withConfig({ 'tables.style': 'preview', 'tables.cjkWidthRatio': 1 }, () =>
+        parser.extractDecorations(md)
+      );
+      const boxWidthOf = (result: DecorationRange[]) =>
+        byType(result, 'tableCell').find((c) => !c.isHeaderCell)!.boxWidth;
+      expect(boxWidthOf(wide)).toBe(8); // 3 chars × 2 + 2 padding
+      expect(boxWidthOf(narrow)).toBe(5); // 3 chars × 1 + 2 padding
+    });
+
+    it('should clamp columns to maxColumnWidth', () => {
+      const md = '| Header |\n|--------|\n| ' + 'x'.repeat(80) + ' |';
+      const result = withConfig({ 'tables.style': 'preview', 'tables.maxColumnWidth': 10 }, () =>
+        parser.extractDecorations(md)
+      );
+      byType(result, 'tableCell').forEach((c) => {
+        // 10 character widths of content plus the padding on either side
+        expect(c.boxWidth).toBe(12);
       });
     });
   });
 
   describe('inline formatting in cells', () => {
+    usePreviewStyle();
+
     it('should detect bold cell style', () => {
       const md = '| A |\n|---|\n| **bold** |';
       const result = parser.extractDecorations(md);
@@ -130,14 +229,14 @@ describe('MarkdownParser - Tables', () => {
       const md = '| Header   |\n|----------|\n| **bold** |';
       const result = parser.extractDecorations(md);
       const cells = byType(result, 'tableCell');
-      // "bold" (4 chars) should be padded relative to "Header" (6 chars),
-      // not "**bold**" (8 chars)
+      // "bold" (4 chars) sizes the column against "Header" (6 chars),
+      // not against "**bold**" (8 chars)
       const boldCell = cells.find((c) => c.replacement!.includes('bold'));
       expect(boldCell).toBeDefined();
       const headerCell = cells.find((c) => c.replacement!.includes('Header'));
       expect(headerCell).toBeDefined();
-      // Both replacements should be same total length (aligned columns)
-      expect(boldCell!.replacement!.length).toBe(headerCell!.replacement!.length);
+      expect(boldCell!.boxWidth).toBe(headerCell!.boxWidth);
+      expect(headerCell!.boxWidth).toBe(8); // "Header" is 6 wide plus padding
     });
   });
 
@@ -155,9 +254,18 @@ describe('MarkdownParser - Tables', () => {
       const cells = byType(result, 'tableCell');
       expect(cells.length).toBeGreaterThanOrEqual(2);
     });
+
+    it('should not decorate tables inside code blocks', () => {
+      const md = '```\n| A | B |\n|---|---|\n| 1 | 2 |\n```';
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableCell')).toHaveLength(0);
+      expect(byType(result, 'tableRule')).toHaveLength(0);
+    });
   });
 
-  describe('outer-pipe-less tables', () => {
+  describe('outer-pipe-less tables (preview style)', () => {
+    usePreviewStyle();
+
     it('should render outer-pipe-less table when it starts at document offset 0', () => {
       const md = 'A | B\n---|---\n1 | 2';
       const result = parser.extractDecorations(md);
@@ -167,7 +275,7 @@ describe('MarkdownParser - Tables', () => {
       expect(cells.every((c) => c.startPos >= 0 && c.endPos > c.startPos)).toBe(true);
       pipes.forEach((p) => {
         expect(p.startPos).toBeGreaterThanOrEqual(0);
-        expect(p.replacement).toBe('\u2502');
+        expect(p.replacement).toBe('');
       });
     });
 
@@ -178,21 +286,54 @@ describe('MarkdownParser - Tables', () => {
       expect(cells.length).toBeGreaterThanOrEqual(4);
     });
 
-    it('should render separator for outer-pipe-less table', () => {
+    it('should render a rule for the separator row of an outer-pipe-less table', () => {
       const md = 'A | B\n---|---\n1 | 2';
       const result = parser.extractDecorations(md);
-      const sepDashes = byType(result, 'tableSeparatorDash');
-      expect(sepDashes.length).toBeGreaterThanOrEqual(2);
+      expect(byType(result, 'tableRule')).toHaveLength(1);
     });
+  });
 
-    it('should not create pipe decorations for virtual boundary positions', () => {
-      const md = 'A | B\n---|---\n1 | 2';
+  describe('grid style (the default)', () => {
+    it('should replace pipes with box-drawing characters', () => {
+      const md = '| A | B |\n|---|---|\n| 1 | 2 |';
       const result = parser.extractDecorations(md);
       const pipes = byType(result, 'tablePipe');
-      // Virtual boundaries should not be decorated; all real pipes get │
+      expect(pipes.length).toBeGreaterThanOrEqual(6);
       pipes.forEach((p) => {
-        expect(p.replacement).toBe('\u2502');
+        expect(p.replacement).toBe('│');
       });
+    });
+
+    it('should pad cells with non-breaking spaces instead of using CSS boxes', () => {
+      const md = '| Name | Age |\n|------|-----|\n| Jo   | 5   |';
+      const result = parser.extractDecorations(md);
+      const cells = byType(result, 'tableCell');
+      expect(cells.length).toBeGreaterThanOrEqual(4);
+      cells.forEach((c) => {
+        expect(c.replacement!.startsWith(' ')).toBe(true);
+        expect(c.replacement!.endsWith(' ')).toBe(true);
+        expect(c.boxWidth).toBeUndefined();
+      });
+    });
+
+    it('should keep separator pipes and dashes and emit no rule', () => {
+      const md = '| A | B |\n|---|---|\n| 1 | 2 |';
+      const result = parser.extractDecorations(md);
+      expect(byType(result, 'tableSeparatorPipe').length).toBeGreaterThanOrEqual(3);
+      expect(byType(result, 'tableSeparatorDash').length).toBeGreaterThanOrEqual(2);
+      expect(byType(result, 'tableRule')).toHaveLength(0);
+    });
+
+    it('should pad according to column alignment', () => {
+      const alignedTable = [
+        '| Left | Center | Right |',
+        '|:-----|:------:|------:|',
+        '| a    |   b    |     c |',
+      ].join('\n');
+      const result = parser.extractDecorations(alignedTable);
+      const cells = byType(result, 'tableCell');
+      const rightCell = cells.find((c) => c.replacement!.includes('c'));
+      expect(rightCell!.replacement!.endsWith('c ')).toBe(true);
     });
   });
 

--- a/src/parser/core.ts
+++ b/src/parser/core.ts
@@ -33,6 +33,7 @@ import {
   scanMentionAndIssueRefs as scanMentionAndIssueRefsHelper,
 } from "./mentions";
 import {
+  CELL_PADDING_CH,
   cellHasMixedFormatting as cellHasMixedFormattingHelper,
   computeColumnWidths as computeColumnWidthsHelper,
   detectCellStyle as detectCellStyleHelper,
@@ -1364,17 +1365,28 @@ export class MarkdownParser {
    * @returns Array of column widths (one per column, minimum 3)
    */
   private computeColumnWidths(tableNode: Table, source: string): number[] {
-    return computeColumnWidthsHelper(tableNode, source);
+    return computeColumnWidthsHelper(tableNode, source, {
+      cjkWidthRatio: config.tables.cjkWidthRatio(),
+      maxColumnWidth: config.tables.style() === "preview"
+        ? config.tables.maxColumnWidth()
+        : undefined,
+    });
   }
 
   /**
    * Processes a GFM table node and emits decorations for pipes, cells, and the separator row.
    *
-   * Produces:
-   * - `tablePipe` decorations for `|` in header and data rows (replaced with `│`)
-   * - `tableSeparatorPipe` decorations for `|` in the separator row (replaced with `├`, `┼`, or `┤`)
-   * - `tableSeparatorDash` decorations for dash segments in the separator row (replaced with `─` repeats)
-   * - `tableCell` decorations for cell content (padded to uniform column width)
+   * In `preview` style (the default) the result mirrors the markdown preview:
+   * - `tablePipe` / `tableSeparatorPipe` decorations that hide the `|` characters
+   * - `tableCell` decorations carrying the plain cell text plus the box width, alignment
+   *   and header flag; the renderer lays each cell out as a fixed-width box so columns
+   *   line up regardless of how the editor font renders full-width characters
+   * - one `tableRule` decoration replacing the whole separator row with a horizontal line
+   *
+   * In `grid` style the original character-grid output is produced instead:
+   * - `tablePipe` / `tableSeparatorPipe` replaced with `│`
+   * - `tableSeparatorDash` replaced with runs of `-`
+   * - `tableCell` padded with non-breaking spaces to a uniform column width
    *
    * Also adds a scope for the entire table so the visibility model can reveal the
    * whole block when the cursor is inside it.
@@ -1397,6 +1409,11 @@ export class MarkdownParser {
     const tableEnd = node.position!.end.offset!;
     const colWidths = this.computeColumnWidths(node, text);
     const colAligns = node.align ?? [];
+    const isPreviewStyle = config.tables.style() === "preview";
+    const drawRowSeparators = isPreviewStyle && config.tables.rowSeparators();
+    // Each preview cell box is the content width plus one character width of padding
+    // on either side, which stands in for the hidden pipe.
+    const boxWidthOf = (colWidth: number): number => colWidth + CELL_PADDING_CH * 2;
 
     this.addScope(scopes, tableStart, tableEnd, "table");
 
@@ -1425,7 +1442,8 @@ export class MarkdownParser {
             startPos: pipes[pIdx],
             endPos: pipes[pIdx] + 1,
             type: "tablePipe",
-            replacement: "\u2502", // │
+            // Preview style hides the pipe; padding inside the cell boxes replaces it.
+            replacement: isPreviewStyle ? "" : "\u2502", // │
           });
         }
       }
@@ -1449,9 +1467,25 @@ export class MarkdownParser {
         const displayContent = (astCell && !showRaw)
           ? this.extractCellPlainText(astCell)
           : trimmedContent;
+        const align = i < colAligns.length ? colAligns[i] : null;
+
+        if (isPreviewStyle) {
+          decorations.push({
+            startPos: cellRangeStart,
+            endPos: cellRangeEnd,
+            type: "tableCell",
+            replacement: displayContent,
+            cellStyle,
+            boxWidth: boxWidthOf(colWidth),
+            cellAlign: align === "right" || align === "center" ? align : "left",
+            isHeaderCell: rowIdx === 0,
+            drawRowSeparator: drawRowSeparators && rowIdx > 0,
+          });
+          continue;
+        }
+
         const displayWidth = this.measureTextWidth(displayContent);
         const totalPad = Math.max(0, colWidth - displayWidth);
-        const align = i < colAligns.length ? colAligns[i] : null;
 
         let replacement: string;
         if (align === "right") {
@@ -1496,6 +1530,26 @@ export class MarkdownParser {
         }
 
         const trimmedSepEnd = this.trimLineEnd(text, sepLineStart, sepLineEnd);
+
+        // Preview style: the whole separator row becomes a single rule spanning the
+        // table, which doubles as the underline of the header row.
+        if (isPreviewStyle) {
+          if (trimmedSepEnd > sepLineStart) {
+            const ruleWidth = colWidths.reduce(
+              (total, colWidth) => total + boxWidthOf(colWidth),
+              0,
+            );
+            decorations.push({
+              startPos: sepLineStart,
+              endPos: trimmedSepEnd,
+              type: "tableRule",
+              replacement: "",
+              boxWidth: ruleWidth,
+            });
+          }
+          continue;
+        }
+
         const rawSepPipes = this.findPipePositions(text, sepLineStart, trimmedSepEnd);
         const { positions: sepPipes, isVirtual: sepIsVirtual } = this.normalizePipePositions(
           text, sepLineStart, trimmedSepEnd, rawSepPipes,

--- a/src/parser/tables.ts
+++ b/src/parser/tables.ts
@@ -71,24 +71,67 @@ export function detectCellStyle(
   return undefined;
 }
 
-export function measureTextWidth(plain: string): number {
+/**
+ * Display width of a full-width character relative to an ASCII character, used when the
+ * caller does not supply one. 2 matches fonts where a full-width glyph occupies exactly
+ * two half-width cells.
+ */
+export const DEFAULT_CJK_WIDTH_RATIO = 2;
+
+/**
+ * Horizontal padding inside a preview-style cell box, in character widths. It stands in
+ * for the hidden `|` and keeps neighbouring columns from touching.
+ */
+export const CELL_PADDING_CH = 1;
+
+/** Options controlling how column widths are estimated. */
+export interface TableWidthOptions {
+  /** Display width of a full-width character, relative to an ASCII character. */
+  cjkWidthRatio?: number;
+  /** Upper bound for a single column, in character widths. */
+  maxColumnWidth?: number;
+}
+
+/**
+ * Reports whether a code point is rendered full-width (East Asian Wide / Fullwidth).
+ *
+ * Covers kana, CJK ideographs, Hangul, CJK punctuation and the fullwidth forms block —
+ * the last one matters for Japanese text, where `（` and `）` are common.
+ *
+ * @param {number} code - Unicode code point
+ * @returns {boolean} True when the character occupies two character cells
+ */
+export function isFullWidth(code: number): boolean {
+  return (
+    (code >= 0x1100 && code <= 0x115f) || // Hangul Jamo
+    (code >= 0x2e80 && code <= 0x9fff) || // CJK radicals, kana, punctuation, unified ideographs
+    (code >= 0xa960 && code <= 0xa97f) || // Hangul Jamo Extended-A
+    (code >= 0xac00 && code <= 0xd7a3) || // Hangul syllables
+    (code >= 0xf900 && code <= 0xfaff) || // CJK compatibility ideographs
+    (code >= 0xfe10 && code <= 0xfe19) || // Vertical forms
+    (code >= 0xfe30 && code <= 0xfe6f) || // CJK compatibility forms, small form variants
+    (code >= 0xff00 && code <= 0xff60) || // Fullwidth forms, e.g. fullwidth parentheses
+    (code >= 0xffe0 && code <= 0xffe6) || // Fullwidth signs
+    (code >= 0x20000 && code <= 0x2fa1f) // CJK extension B and beyond
+  );
+}
+
+/**
+ * Estimates the display width of a string in character widths (ASCII character = 1).
+ *
+ * @param {string} plain - Text to measure
+ * @param {number} cjkWidthRatio - Width of a full-width character relative to an ASCII one
+ * @returns {number} Estimated width, possibly fractional
+ */
+export function measureTextWidth(
+  plain: string,
+  cjkWidthRatio: number = DEFAULT_CJK_WIDTH_RATIO,
+): number {
   let width = 0;
-  let cjkCount = 0;
   for (const char of plain) {
-    const code = char.codePointAt(0)!;
-    if (
-      (code >= 0x2e80 && code <= 0x9fff) ||
-      (code >= 0xf900 && code <= 0xfaff) ||
-      (code >= 0xfe30 && code <= 0xfe4f) ||
-      (code >= 0x20000 && code <= 0x2fa1f)
-    ) {
-      width += 2;
-      cjkCount++;
-    } else {
-      width += 1;
-    }
+    width += isFullWidth(char.codePointAt(0)!) ? cjkWidthRatio : 1;
   }
-  return width + Math.ceil(cjkCount * 0.25);
+  return width;
 }
 
 export function findPipePositions(
@@ -163,7 +206,13 @@ export function trimLineEnd(text: string, lineStart: number, lineEnd: number): n
   return end;
 }
 
-export function computeColumnWidths(tableNode: Table, source: string): number[] {
+export function computeColumnWidths(
+  tableNode: Table,
+  source: string,
+  options: TableWidthOptions = {},
+): number[] {
+  const cjkWidthRatio = options.cjkWidthRatio ?? DEFAULT_CJK_WIDTH_RATIO;
+  const maxColumnWidth = options.maxColumnWidth ?? Number.POSITIVE_INFINITY;
   let numCols = 0;
 
   for (const row of tableNode.children) {
@@ -193,12 +242,12 @@ export function computeColumnWidths(tableNode: Table, source: string): number[] 
       const displayText = (astCell && !showRaw)
         ? extractCellPlainText(astCell)
         : cellText;
-      const width = measureTextWidth(displayText);
+      const width = measureTextWidth(displayText, cjkWidthRatio);
       if (width > widths[i]) widths[i] = width;
     }
   }
 
-  return widths;
+  return widths.map((width) => Math.min(maxColumnWidth, Math.ceil(width)));
 }
 
 export function addTableScope(scopes: ScopeRange[], tableStart: number, tableEnd: number): void {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -15,6 +15,14 @@ export interface DecorationRange {
   issueNumber?: number;
   ownerRepo?: string;
   orderedListMarkerMismatch?: boolean;
+  /** Preview-style tables: width of the cell (or rule) box, in character widths. */
+  boxWidth?: number;
+  /** Preview-style tables: horizontal alignment of the cell content. */
+  cellAlign?: "left" | "center" | "right";
+  /** Preview-style tables: the cell belongs to the header row and is rendered bold. */
+  isHeaderCell?: boolean;
+  /** Preview-style tables: draw a thin rule along the bottom edge of the cell box. */
+  drawRowSeparator?: boolean;
 }
 
 export interface ScopeRange {
@@ -78,6 +86,7 @@ export type DecorationType =
   | "tablePipe"
   | "tableSeparatorPipe"
   | "tableSeparatorDash"
+  | "tableRule"
   | "tableCell"
   | "mention"
   | "issueReference";

--- a/src/registration/__tests__/register-event-handlers.test.ts
+++ b/src/registration/__tests__/register-event-handlers.test.ts
@@ -158,4 +158,40 @@ describe('registerEventHandlers', () => {
     expect(decorator.recreateColorDependentTypes).toHaveBeenCalledTimes(2);
     expect(decorator.clearMathDecorationCache).toHaveBeenCalledTimes(1);
   });
+
+  it('drops the parse cache when a table setting changes', () => {
+    let configurationListener:
+      | ((event: { affectsConfiguration: (section: string) => boolean }) => void)
+      | undefined;
+
+    vscode.workspace.onDidChangeConfiguration = vi.fn((listener) => {
+      configurationListener = listener;
+      return { dispose: vi.fn() };
+    }) as any;
+
+    const decorator = {
+      setActiveEditor: vi.fn(),
+      updateDecorationsForSelection: vi.fn(),
+      updateDecorationsFromChange: vi.fn(),
+      renameFile: vi.fn(),
+      updateDiffViewDecorationSetting: vi.fn(),
+      recreateGhostFaintDecorationType: vi.fn(),
+      recreateFrontmatterDelimiterDecorationType: vi.fn(),
+      recreateCodeBlockLanguageDecorationType: vi.fn(),
+      recreateColorDependentTypes: vi.fn(),
+      clearMathDecorationCache: vi.fn(),
+      clearCache: vi.fn(),
+    };
+    const linkClickHandler = { setEnabled: vi.fn() };
+
+    registerEventHandlers(decorator as any, linkClickHandler as any);
+
+    configurationListener?.({
+      affectsConfiguration: (section: string) => section === 'markdownInlineEditor.tables',
+    });
+
+    // Table settings feed the parser, so the cached decorations have to be discarded
+    expect(decorator.clearCache).toHaveBeenCalledTimes(1);
+    expect(decorator.updateDecorationsForSelection).toHaveBeenCalled();
+  });
 });

--- a/src/registration/register-event-handlers.ts
+++ b/src/registration/register-event-handlers.ts
@@ -51,6 +51,13 @@ export function registerEventHandlers(
         decorator.recreateLinkDecorationType();
       }
 
+      if (event.affectsConfiguration('markdownInlineEditor.tables')) {
+        // Table settings change the parsed decorations themselves (column widths,
+        // replacement text), so the cached parse has to go before redrawing.
+        decorator.clearCache();
+        decorator.updateDecorationsForSelection();
+      }
+
       if (event.affectsConfiguration('markdownInlineEditor.colors')) {
         decorator.recreateColorDependentTypes();
       }


### PR DESCRIPTION
## Problem

Table cells are padded with non-breaking spaces to a width measured from the source text (`parser/tables.ts` `measureTextWidth`, `parser/core.ts` `processTable`). That approach only lines up when the editor font renders a full-width glyph at exactly the assumed ratio. In practice:

- **CJK + ASCII tables come out ragged.** The default font stack on Windows is `Consolas` with a system fallback for Japanese; the fallback's advance width is not 2× Consolas' `0`, so every full-width character accumulates error across the row.
- **Proportional fonts can't work at all** by construction (#41).
- **Hidden markup shifts columns** (#21), because the padding is computed from a width the renderer never actually produces.
- The width scan also misses the **fullwidth forms block (U+FF00–FF60)**, so `（` and `）` — extremely common in Japanese prose — measure as one column instead of two.

## Approach

Add an opt-in `preview` style that lays each cell out as a **fixed-width CSS box** instead of padding it with spaces:

```
before: {
  contentText: <cell text>,
  textDecoration: 'none; display: inline-block; box-sizing: border-box; width: 24ch; padding: 0 1ch; overflow: hidden; text-align: left; …'
}
```

The key property is that **every cell in a column gets the same width**, so the grid is straight regardless of what the font does. The width estimate now only decides whether the text *fits*, not whether the table is aligned — which demotes font metrics from a correctness problem to a tuning knob.

The CSS-injection-through-`textDecoration` technique is not new here: `createCheckboxBeforeOptions` and the mermaid decorations already use it.

Pipes are hidden and the separator row becomes a single rule, matching the preview pane.

## Non-breaking

`tables.style` defaults to **`grid`**, so nothing changes for existing users unless they opt in. I'd be glad to flip the default to `preview` if you'd prefer — the grid path is font-dependent by construction, so `preview` is arguably the better default — but that's your call, so I kept this purely additive.

The CJK measurement fixes (fullwidth forms, configurable ratio) apply to **both** paths, so grid users get those regardless.

## Settings added

| Setting | Default | Purpose |
|---|---|---|
| `tables.style` | `grid` | `grid` \| `preview` |
| `tables.cjkWidthRatio` | `2` | Full-width character width relative to ASCII |
| `tables.maxColumnWidth` | `48` | Caps a column, in character widths (preview only) |
| `tables.rowSeparators` | `true` | Thin rule under each data row (preview only) |

## Relationship to #116

**`tables.cjkWidthRatio` overlaps with @nazoking's #116**, which proposed the same setting for the grid path. I only found it after writing this. If you'd rather merge #116 first, I'm happy to rebase and drop that part of this PR, or to close this and re-submit on top — just say which you prefer.

## Known limitation

Cells cannot wrap: an editor line maps to one visual line, so there is no vertical room to reflow into. Content past `maxColumnWidth` is clipped in the rendered view and shown in full when the cursor enters the table. Wide tables are best viewed with `editor.wordWrap` off, since a wrapped row breaks the run of cell boxes — related to #76.

This is why I did *not* go the "render the table as an SVG like mermaid" route discussed in #76: it would need a hand-written layout engine and still couldn't add the vertical space that wrapping requires.

## Tests

`npm run lint`, `npm run lint:docs` and the full Vitest suite pass (833 tests). Added coverage for:

- box width uniformity across a column, header flags, row separators, and the rule spanning the table
- CJK sizing, fullwidth parentheses, custom `cjkWidthRatio`, `maxColumnWidth` clamping
- the emitted CSS in `visibility-model` (box layout, alignment, borders, cell-style `text-decoration` preserved as the base value)
- grid style regression tests, so the existing behaviour stays pinned
- config parsing/clamping and parse-cache invalidation on setting change

Docs follow the repo convention: `docs/features/done/preview-style-tables.md` (passes `validate-feature-outline.js`) and a status note on the "Table column alignment (with markup)" entry in `docs/features/todo.md`.
