### PR TITLE
fix(math): ignore dollar signs in inline code and bound math to paragraphs

### DIFF
--- a/src/math/__tests__/math-scanner.test.ts
+++ b/src/math/__tests__/math-scanner.test.ts
@@ -141,4 +141,29 @@ describe('scanMathRegions - fence-aware behavior', () => {
     const text = '```math\na+b';
     expect(scanMathRegions(text)).toHaveLength(0);
   });
+
+  it('skips $ inside inline code backticks', () => {
+    const text = 'The regex `^(\\d{4})$` matches years, not math.';
+    const regions = scanMathRegions(text);
+    expect(regions).toHaveLength(0);
+  });
+
+  it('does not allow inline math to span across blank lines / paragraph boundaries', () => {
+    const text = 'Here is a price $10\n\nAnd another price $20';
+    const regions = scanMathRegions(text);
+    expect(regions).toHaveLength(0);
+  });
+
+  it('correctly isolates inline code with regex $ from subsequent valid inline math', () => {
+    const text = [
+      '**Clarification**: The ISO regex at line 51 (`/^(\\d{4})(?:-(\\d{1,2}))?(?:-(\\d{1,2}))?$/`) matches hyphens only.',
+      '',
+      '- **Resolution**: Ambiguous month/day numbers ($\\le 12$) return `null`.',
+    ].join('\n');
+
+    const regions = scanMathRegions(text);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].source).toBe('\\le 12');
+    expect(regions[0].displayMode).toBe(false);
+  });
 });

--- a/src/math/math-scanner.ts
+++ b/src/math/math-scanner.ts
@@ -207,6 +207,12 @@ function tryMatchInline(text: string, start: number, ignoredRanges: IgnoredRange
   return null;
 }
 
+/**
+ * Scans document text for inline code spans (`...` or ``...``) outside fenced code blocks.
+ * Matches exact backtick sequence lengths according to CommonMark spec.
+ * Used to ensure $ characters inside inline code (e.g. regex anchors, shell variables)
+ * are never erroneously parsed as math delimiters.
+ */
 function scanInlineCodeSpans(text: string, fencedBlocks: FencedCodeBlock[]): IgnoredRange[] {
   const spans: IgnoredRange[] = [];
   let i = 0;
@@ -224,6 +230,7 @@ function scanInlineCodeSpans(text: string, fencedBlocks: FencedCodeBlock[]): Ign
     }
 
     if (text[i] === '`') {
+      // Measure opening delimiter run length (e.g. ` or ``)
       let backtickLen = 1;
       while (i + backtickLen < n && text[i + backtickLen] === '`') {
         backtickLen++;
@@ -232,6 +239,7 @@ function scanInlineCodeSpans(text: string, fencedBlocks: FencedCodeBlock[]): Ign
       let searchPos = i + backtickLen;
       let closePos = -1;
 
+      // Find matching closing backtick run of the exact same length per CommonMark
       while (searchPos < n) {
         if (fenceIdx < fencedBlocks.length && searchPos >= fencedBlocks[fenceIdx].startPos) {
           break;

--- a/src/math/math-scanner.ts
+++ b/src/math/math-scanner.ts
@@ -17,6 +17,11 @@ type FencedCodeBlock = {
 
 const MATH_FENCE_LANGUAGES = new Set(['math', 'latex', 'tex']);
 
+type IgnoredRange = {
+  startPos: number;
+  endPos: number;
+};
+
 /**
  * Scans text for math regions. Block math ($$...$$) is tried first; then inline ($...$).
  * Escaped \$ does not start/end; empty or whitespace-only content is not treated as math.
@@ -28,18 +33,28 @@ const MATH_FENCE_LANGUAGES = new Set(['math', 'latex', 'tex']);
  */
 export function scanMathRegions(text: string): MathRegion[] {
   const fencedBlocks = scanFencedCodeBlocks(text);
+  const inlineCodeSpans = scanInlineCodeSpans(text, fencedBlocks);
+
+  // All non-math code ranges where $ should be completely ignored:
+  // - Non-math fenced code blocks
+  // - Inline code spans
+  const ignoredRanges: IgnoredRange[] = [
+    ...fencedBlocks.filter((f) => !f.isMathFence).map((f) => ({ startPos: f.startPos, endPos: f.endPos })),
+    ...inlineCodeSpans,
+  ].sort((a, b) => a.startPos - b.startPos);
+
   const regions: MathRegion[] = [];
   let i = 0;
   const n = text.length;
-  let fenceIndex = 0;
+  let ignoredIndex = 0;
 
   while (i < n) {
-    while (fenceIndex < fencedBlocks.length && fencedBlocks[fenceIndex].endPos <= i) {
-      fenceIndex++;
+    while (ignoredIndex < ignoredRanges.length && ignoredRanges[ignoredIndex].endPos <= i) {
+      ignoredIndex++;
     }
-    const activeFence = fencedBlocks[fenceIndex];
-    if (activeFence && i >= activeFence.startPos && i < activeFence.endPos) {
-      i = activeFence.endPos;
+    const activeIgnored = ignoredRanges[ignoredIndex];
+    if (activeIgnored && i >= activeIgnored.startPos && i < activeIgnored.endPos) {
+      i = activeIgnored.endPos;
       continue;
     }
 
@@ -49,7 +64,7 @@ export function scanMathRegions(text: string): MathRegion[] {
         i++;
         continue;
       }
-      const block = tryMatchBlock(text, i);
+      const block = tryMatchBlock(text, i, ignoredRanges);
       if (block) {
         regions.push(block);
         i = block.endPos;
@@ -62,7 +77,7 @@ export function scanMathRegions(text: string): MathRegion[] {
 
     // Inline: single $ then find next unescaped $; content between is trimmed and must be non-empty
     if (text[i] === '$' && !isEscaped(text, i)) {
-      const inline = tryMatchInline(text, i);
+      const inline = tryMatchInline(text, i, ignoredRanges);
       if (inline) {
         regions.push(inline);
         i = inline.endPos;
@@ -108,13 +123,17 @@ function isEscaped(text: string, dollarIndex: number): boolean {
   return backslashes % 2 === 1;
 }
 
-function tryMatchBlock(text: string, start: number): MathRegion | null {
+function tryMatchBlock(text: string, start: number, ignoredRanges: IgnoredRange[]): MathRegion | null {
   if (start + 4 > text.length) return null;
   if (text[start] !== '$' || text[start + 1] !== '$') return null;
   let i = start + 2;
   while (i < text.length) {
     const idx = text.indexOf('$$', i);
     if (idx === -1) return null;
+    if (ignoredRanges.some((r) => idx >= r.startPos && idx < r.endPos)) {
+      i = idx + 2;
+      continue;
+    }
     if (isEscapedAt(text, idx)) {
       i = idx + 1;
       continue;
@@ -145,12 +164,30 @@ function isEscapedAt(text: string, idx: number): boolean {
   return backslashes % 2 === 1;
 }
 
-function tryMatchInline(text: string, start: number): MathRegion | null {
+function tryMatchInline(text: string, start: number, ignoredRanges: IgnoredRange[]): MathRegion | null {
   if (text[start] !== '$') return null;
   let i = start + 1;
   while (i < text.length) {
     const idx = text.indexOf('$', i);
     if (idx === -1) return null;
+
+    // Inline math cannot cross blank lines (paragraph breaks)
+    const between = text.slice(start, idx);
+    if (/\n[ \t]*\r?\n/.test(between)) {
+      return null;
+    }
+
+    // Abort if an ignored code span starts between start and idx
+    if (ignoredRanges.some((r) => r.startPos > start && r.startPos < idx)) {
+      return null;
+    }
+
+    // Skip if closing delimiter falls inside an ignored code span
+    if (ignoredRanges.some((r) => idx >= r.startPos && idx < r.endPos)) {
+      i = idx + 1;
+      continue;
+    }
+
     if (isEscapedAt(text, idx)) {
       i = idx + 1;
       continue;
@@ -168,6 +205,62 @@ function tryMatchInline(text: string, start: number): MathRegion | null {
     };
   }
   return null;
+}
+
+function scanInlineCodeSpans(text: string, fencedBlocks: FencedCodeBlock[]): IgnoredRange[] {
+  const spans: IgnoredRange[] = [];
+  let i = 0;
+  let fenceIdx = 0;
+  const n = text.length;
+
+  while (i < n) {
+    while (fenceIdx < fencedBlocks.length && fencedBlocks[fenceIdx].endPos <= i) {
+      fenceIdx++;
+    }
+    const currentFence = fencedBlocks[fenceIdx];
+    if (currentFence && i >= currentFence.startPos && i < currentFence.endPos) {
+      i = currentFence.endPos;
+      continue;
+    }
+
+    if (text[i] === '`') {
+      let backtickLen = 1;
+      while (i + backtickLen < n && text[i + backtickLen] === '`') {
+        backtickLen++;
+      }
+      const closeMarker = '`'.repeat(backtickLen);
+      let searchPos = i + backtickLen;
+      let closePos = -1;
+
+      while (searchPos < n) {
+        if (fenceIdx < fencedBlocks.length && searchPos >= fencedBlocks[fenceIdx].startPos) {
+          break;
+        }
+        const found = text.indexOf(closeMarker, searchPos);
+        if (found === -1) break;
+        let count = backtickLen;
+        while (found + count < n && text[found + count] === '`') {
+          count++;
+        }
+        if (count === backtickLen) {
+          closePos = found;
+          break;
+        }
+        searchPos = found + count;
+      }
+
+      if (closePos !== -1) {
+        const spanEnd = closePos + backtickLen;
+        spans.push({ startPos: i, endPos: spanEnd });
+        i = spanEnd;
+        continue;
+      }
+      i += backtickLen;
+      continue;
+    }
+    i++;
+  }
+  return spans;
 }
 
 function scanFencedCodeBlocks(text: string): FencedCodeBlock[] {


### PR DESCRIPTION
> [!NOTE]
> - **Closes**: #92

## Before (Issue)

- **Paragraph 1**: The `?$/` inside the regex was mistaken for an opening math delimiter.
- **Paragraph 2**: The next paragraph's formula `($\le 12$)` had its opening `$` stolen by the previous paragraph, leaving the rest rendered as broken raw text.
<img width="888" height="119" alt="Screenshot 2026-08-29 160546" src="https://github.com/user-attachments/assets/7cf550f6-2b6d-4b36-84b8-69b0b67c1400" />

## After

- **Paragraph 1**: No mistaken math delimiters.
- **Paragraph 2**: Properly rendered formula in next line.
<img width="865" height="128" alt="Screenshot 2026-08-29 160730" src="https://github.com/user-attachments/assets/f76e454d-ceab-401d-8278-db9338ad9b14" />

## Summary of Changes

- **Ignore inline code spans in math scanner**: `scanMathRegions` now scans and skips inline code backtick spans (`` `...` ``). Previously, only fenced code blocks were skipped, causing dollar signs inside inline code (e.g. regex anchors like `?$/` or shell variables) to be erroneously parsed as math delimiters.
- **Bound inline math to paragraphs**: In `tryMatchInline`, prevented inline math (`$...$`) from matching across blank lines (`\n\n`) into subsequent paragraphs.
- **Unit Tests**: Added test cases covering dollar signs in inline code, paragraph boundaries, and the scenario where regex inline code precedes legitimate inline math formulas.

## Problem Solved

When Markdown contained inline code with a dollar sign (such as `` ` /^(\d{4})(?:-(\d{1,2}))?(?:-(\d{1,2}))?$/ ` ``), the scanner treated the `$` as an opening inline math delimiter. It then searched across the entire file until reaching the next `$` in another paragraph (e.g. `($\le 12$)`), collapsing the entire intervening text into a single broken math formula and corrupting subsequent math delimiters.