### PR TITLE
fix(parser): support parentheses inside link and image URLs

### DIFF
--- a/src/parser/__tests__/parser-image.test.ts
+++ b/src/parser/__tests__/parser-image.test.ts
@@ -160,5 +160,23 @@ describe('MarkdownParser - Images', () => {
       expect(result.some(d => d.type === 'hide' && d.startPos === 9 && d.endPos === 10)).toBe(true); // closing *
     });
   });
+
+  describe('image with parentheses in URL', () => {
+    it('should hide entire URL and closing parenthesis when URL contains parentheses', () => {
+      const markdown = '![Diagram](https://example.com/assets/diagram_(v1).png)';
+      const result = parser.extractDecorations(markdown);
+
+      const imageDec = result.find(d => d.type === 'image');
+      expect(imageDec).toBeDefined();
+      expect(imageDec?.url).toBe('https://example.com/assets/diagram_(v1).png');
+
+      // The closing parenthesis of the image (last char) must be hidden
+      expect(
+        result.some(
+          d => d.type === 'hide' && d.startPos === markdown.length - 1 && d.endPos === markdown.length
+        )
+      ).toBe(true);
+    });
+  });
 });
 

--- a/src/parser/__tests__/parser-link.test.ts
+++ b/src/parser/__tests__/parser-link.test.ts
@@ -440,5 +440,35 @@ describe('MarkdownParser - Links', () => {
       expect(linkDecs.length).toBe(0);
     });
   });
+
+  describe('link with parentheses in URL', () => {
+    it('should hide entire URL and closing parenthesis when URL contains parentheses', () => {
+      const markdown = '[Wikipedia](https://en.wikipedia.org/wiki/Function_(mathematics))';
+      const result = parser.extractDecorations(markdown);
+      
+      const linkDec = result.find(d => d.type === 'link');
+      expect(linkDec).toBeDefined();
+      expect(linkDec?.url).toBe('https://en.wikipedia.org/wiki/Function_(mathematics)');
+      expect(linkDec?.startPos).toBe(1);
+      expect(linkDec?.endPos).toBe(10); // 'Wikipedia'
+
+      // The entire URL content should be hidden
+      expect(result.some(d => d.type === 'hide' && d.startPos === 12 && d.endPos === 64)).toBe(true);
+      // The closing parenthesis of the link (last char) must be hidden
+      expect(result.some(d => d.type === 'hide' && d.startPos === 64 && d.endPos === 65)).toBe(true);
+    });
+
+    it('should hide entire URL when URL has nested parentheses and trailing path', () => {
+      const markdown = '[Release Notes](https://example.com/item_(v2)_final)';
+      const result = parser.extractDecorations(markdown);
+
+      // The closing parenthesis of the link must be hidden
+      expect(
+        result.some(
+          d => d.type === 'hide' && d.startPos === markdown.length - 1 && d.endPos === markdown.length
+        )
+      ).toBe(true);
+    });
+  });
 });
 

--- a/src/parser/core.ts
+++ b/src/parser/core.ts
@@ -754,8 +754,9 @@ export class MarkdownParser {
         type: "hide",
       });
 
-      const parenEnd = text.indexOf(")", parenStart + 1);
-      if (parenEnd !== -1 && parenEnd <= end) {
+      // Find closing parenthesis of the link (search backwards from end to handle parens in URL)
+      const parenEnd = text.lastIndexOf(")", end - 1);
+      if (parenEnd !== -1 && parenEnd > parenStart && parenEnd <= end) {
         // Hide URL content between parentheses
         const urlStart = parenStart + 1;
         if (urlStart < parenEnd) {
@@ -879,8 +880,9 @@ export class MarkdownParser {
           type: "hide",
         });
 
-        const parenEnd = text.indexOf(")", parenStart + 1);
-        if (parenEnd !== -1 && parenEnd <= end) {
+        // Find closing parenthesis of the image (search backwards from end to handle parens in URL)
+        const parenEnd = text.lastIndexOf(")", end - 1);
+        if (parenEnd !== -1 && parenEnd > parenStart && parenEnd <= end) {
           const urlStart = parenStart + 1;
           if (urlStart < parenEnd) {
             decorations.push({


### PR DESCRIPTION
## Before (Issue)

When a link or image URL contains parentheses (such as Wikipedia articles, API reference docs, or versioned asset paths might do), the markdown delimiters fail to hide properly:

<img width="524" height="52" alt="Screenshot 2026-08-29 171243" src="https://github.com/user-attachments/assets/9f59672b-682c-4ac0-8b97-4396456140aa" />

- `[Wikipedia](https://en.wikipedia.org/wiki/Function_(mathematics))` rendered as `Wikipedia)` with a dangling closing parenthesis.
- `![Diagram](.../diagram_(v1).png)` rendered as the diagram followed by raw text `.png)`.

## After

<img width="529" height="59" alt="Screenshot 2026-08-29 171300" src="https://github.com/user-attachments/assets/7691fada-8236-4fa9-bf76-7bca3ba3093b" />

## Root Cause

In `src/parser/core.ts` (`processLink` and `processImage`), the parser previously used:
```ts
const parenEnd = text.indexOf(")", parenStart + 1);
```
This forward search stopped at the **first** closing parenthesis found inside the URL path, causing the hide range to terminate prematurely and leaving the remainder of the URL and the link's true closing parenthesis unhidden in the editor.

## Solution

**Backwards Search from Node Boundary**:
In both `processLink` and `processImage`, changed the closing parenthesis lookup to search backwards from the AST node's known end offset:
```ts
const parenEnd = text.lastIndexOf(")", end - 1);
```
Because Remark's AST node (`node.position.end.offset`) already knows the exact end boundary of the link/image, searching backwards from `end - 1` reliably identifies the true closing parenthesis of the markdown construct, hiding the entire URL and both delimiters regardless of internal parentheses.

## Testing

- **Dedicated Unit Tests Added** for `link` and `image` parser.
- **Test Efficacy Verified**: reverting the fix causes these tests to fail.