### PR TITLE
fix(parser): validate opening frontmatter delimiter line format

### DIFF
--- a/src/parser/__tests__/parser-frontmatter.test.ts
+++ b/src/parser/__tests__/parser-frontmatter.test.ts
@@ -149,6 +149,29 @@ title: Document
       expect(result.some(d => d.type === 'frontmatter')).toBe(false);
     });
 
+    // Note: The tests above verify that extra text on the CLOSING delimiter is correctly rejected.
+    // Symmetrically, the OPENING delimiter must also strictly reject extra text (e.g. `--- some text` or `---comment`).
+    // Per the YAML frontmatter standard (Jekyll, Hugo, GitHub), the opening delimiter line must contain only `---`.
+    it('should not treat invalid opening delimiter format as frontmatter', () => {
+      const markdown = `--- some text
+title: Document
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      // Should not have frontmatter decoration (opening delimiter has extra text)
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+    });
+
+    it('should not treat ---comment as opening delimiter', () => {
+      const markdown = `---comment
+title: Document
+---`;
+      const result = parser.extractDecorations(markdown);
+
+      // Should not have frontmatter decoration (opening delimiter has text after ---)
+      expect(result.some(d => d.type === 'frontmatter')).toBe(false);
+    });
+
     it('should not apply decoration for incomplete frontmatter (no closing delimiter)', () => {
       const markdown = `---
 title: Document

--- a/src/parser/frontmatter.ts
+++ b/src/parser/frontmatter.ts
@@ -33,6 +33,12 @@ export function processFrontmatter(
   if (openingLineEnd === -1) {
     return;
   }
+
+  const openingLineContent = text.substring(openingDelimiterStart, openingLineEnd);
+  if (!/^---\s*$/.test(openingLineContent)) {
+    return;
+  }
+
   const openingLineEndPos = openingLineEnd + 1;
 
   let searchPos = openingLineEndPos;


### PR DESCRIPTION
## Before (Issue)

When a document starts with a decorative line or title containing dashes (such as `--- Document Title ---` or `----------------`), followed later by a horizontal rule (`---`), the entire block between them is mistakenly treated as YAML frontmatter:

<img width="211" height="113" alt="Screenshot 2026-08-29 175357" src="https://github.com/user-attachments/assets/c43f42ec-d8ba-4f6d-a3d3-76226d26e526" />

- `--- Document Title ---` and normal paragraph text beneath it get enclosed in a frontmatter box and styled in faint/dimmed text.
- Malformed opening delimiters like `--- something` or `---comment` falsely trigger frontmatter parsing.

## After

<img width="231" height="110" alt="Screenshot 2026-08-29 175607" src="https://github.com/user-attachments/assets/29cf7ca7-6175-4a2c-9fc0-d5a47c5b75d6" />

## Root Cause

In `src/parser/frontmatter.ts` (`processFrontmatter`), the parser strictly validated the closing delimiter using `/^---\s*$/`, but on the opening delimiter line, it only checked whether the line started with three dashes:
```ts
if (
  startPos + MIN_FRONTMATTER_LENGTH > text.length ||
  text.substring(startPos, startPos + MIN_FRONTMATTER_LENGTH) !== '---'
) {
  return;
}
```

It completely omitted checking the remainder of the opening line. Any extra text after `---` on line 1 was ignored, causing non-frontmatter documents to be parsed as frontmatter if any horizontal rule appeared within the next 100 lines (`MAX_FRONTMATTER_SEARCH_LINES `).

## Solution

**Validate Opening Delimiter Line**:
In `src/parser/frontmatter.ts`, added the symmetric `/^---\s*$/` validation for the opening delimiter line:
```ts
const openingLineContent = text.substring(openingDelimiterStart, openingLineEnd);
if (!/^---\s*$/.test(openingLineContent)) {
  return;
}
```
This guarantees that an opening frontmatter delimiter contains only `---` (optionally followed by whitespace), aligning with standard YAML frontmatter specifications and preventing regular text from being dimmed.

## Testing

- **Dedicated Unit Tests Added** for invalid opening delimiter formats.
- **Test Efficacy Verified**: reverting the fix causes these tests to fail.