### PR TITLE
fix(commands): support anchor navigation with CRLF line endings

### DIFF
--- a/src/commands/__tests__/navigate-to-anchor.test.ts
+++ b/src/commands/__tests__/navigate-to-anchor.test.ts
@@ -3,6 +3,10 @@ import * as vscode from 'vscode';
 import { createNavigateToAnchorCommand } from '../navigate-to-anchor';
 
 describe('navigate-to-anchor command', () => {
+  beforeEach(() => {
+    (vscode.window.showInformationMessage as Mock).mockClear();
+  });
+
   it('opens document and selects matching heading', async () => {
     let handler: ((anchor: string, documentUri: string) => Promise<void>) | undefined;
     (vscode.commands.registerCommand as Mock).mockImplementation((_id, cb) => {
@@ -49,5 +53,31 @@ describe('navigate-to-anchor command', () => {
     await handler?.('missing', 'file:///test.md');
 
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Anchor "missing" not found');
+  });
+
+  it('opens document and selects matching heading in CRLF documents', async () => {
+    let handler: ((anchor: string, documentUri: string) => Promise<void>) | undefined;
+    (vscode.commands.registerCommand as Mock).mockImplementation((_id, cb) => {
+      handler = cb;
+      return { dispose: vi.fn() };
+    });
+
+    const document = new (vscode.TextDocument as any)(
+      vscode.Uri.file('/test.md'),
+      'markdown',
+      1,
+      '# Title\r\n## My Heading\r\nContent'
+    );
+    const editor = new (vscode.TextEditor as any)(document, []);
+    editor.revealRange = vi.fn();
+    (vscode.workspace.openTextDocument as Mock).mockResolvedValue(document);
+    (vscode.window.showTextDocument as Mock).mockResolvedValue(editor);
+
+    createNavigateToAnchorCommand();
+    await handler?.('my-heading', 'file:///test.md');
+
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(editor.revealRange).toHaveBeenCalled();
+    expect(editor.selection?.active.line).toBe(1);
   });
 });

--- a/src/commands/navigate-to-anchor.ts
+++ b/src/commands/navigate-to-anchor.ts
@@ -6,7 +6,7 @@ async function navigateToAnchor(anchor: string, documentUri: string): Promise<vo
   const document = await vscode.workspace.openTextDocument(uri);
   const editor = await vscode.window.showTextDocument(document);
   const text = document.getText();
-  const lines = text.split('\n');
+  const lines = text.split(/\r?\n/);
 
   for (let i = 0; i < lines.length; i++) {
     const headingMatch = lines[i].match(/^#+\s+(.+)$/);

--- a/src/position-mapping.ts
+++ b/src/position-mapping.ts
@@ -101,9 +101,10 @@ export function mapNormalizedToOriginal(normalizedPos: number, originalText?: st
  */
 export function normalizeAnchorText(text: string): string {
   return text
+    .trim()
     .toLowerCase()
     .replace(/[^\w\s-]/g, '')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
-    .trim();
+    .replace(/^-+|-+$/g, '');
 }

--- a/src/position-mapping/__tests__/position-mapping.test.ts
+++ b/src/position-mapping/__tests__/position-mapping.test.ts
@@ -75,10 +75,10 @@ describe('normalizeAnchorText', () => {
     expect(normalizeAnchorText('a  b')).toBe('a-b'); // spaces → hyphens → collapsed
   });
 
-  it('converts leading/trailing spaces to hyphens (spaces are replaced before trim)', () => {
-    // Spaces are first replaced with hyphens, then trim() removes only whitespace — not hyphens.
-    // So '  test  ' → '-test-' (spaces at edges become hyphens, trim has nothing to remove).
-    expect(normalizeAnchorText('  test  ')).toBe('-test-');
+  it('trims leading/trailing spaces without creating leading/trailing hyphens', () => {
+    // Matches JSDoc example: normalizeAnchorText('  Test  123  ') returns 'test-123'
+    expect(normalizeAnchorText('  test  ')).toBe('test');
+    expect(normalizeAnchorText('  Test  123  ')).toBe('test-123');
   });
 
   it('handles numbers', () => {


### PR DESCRIPTION
## Issue

In documents using Windows line endings (`CRLF`), clicking any internal anchor link (e.g. `[Jump to Setup](#setup)`) fails with:
`Anchor "setup" not found`.

## Reproduction / Try-out Snippet

1. Save the file with line endings set to **CRLF** in VS Code (or switch bottom right).
2. Click the link:

```markdown
# Table of Contents
[Jump to Setup](#setup)

[... long document content ...]

# Setup
Welcome to the setup guide!
```

## Root Cause

1. **Line Ending Regex Mismatch (`src/commands/navigate-to-anchor.ts`)**:
`text.split('\n')` leaves the trailing carriage return `\r` on each line. In JavaScript regex, `.` does not match `\r`, causing `/^#+\s+(.+)$/` to return `null` on lines ending in `\r`. As a result, heading lines are completely skipped in CRLF files.
2. **Anchor Normalization Trimming (`src/position-mapping.ts`)**:
In `normalizeAnchorText`, `.replace(/\s+/g, '-')` was executed before `.trim()`. Any whitespace at the boundaries was converted to hyphens before trimming, creating trailing/leading hyphens (e.g. `  test  ` became `-test-` instead of `test`, conflicting with the function's own JSDoc).

## Solution

1. **CRLF-aware Line Splitting**: Changed `text.split('\n')` to `text.split(/\r?\n/)` in `src/commands/navigate-to-anchor.ts` so heading matching works reliably across LF and CRLF files.
2. **Proper Slug Trimming**: In `src/position-mapping.ts`, added `.trim()` before hyphen conversion and stripped edge hyphens with `.replace(/^-+|-+$/g, '')`.

## Testing

- **Dedicated CRLF Test Added**: Added a test case in `src/commands/__tests__/navigate-to-anchor.test.ts` verifying that headings in CRLF documents are properly matched and navigated to.
- **Corrected Existing Test Assertion**: Notice that `position-mapping.test.ts` previously asserted the buggy behavior (`expect(normalizeAnchorText('  test  ')).toBe('-test-')`), contradicting the function's own JSDoc example (`normalizeAnchorText('  Test  123  ') -> 'test-123'`).
- **Test Isolation**: Added `beforeEach` mock cleanup to prevent call leakage across test cases in `navigate-to-anchor.test.ts`.
- **Verified Test Failure**: Both tests failed before applying the fix and now pass.