### PR TITLE
fix(parser): prevent false whole-cell styling on mixed and nested table content

### DIFF
--- a/src/parser/__tests__/parser-table.test.ts
+++ b/src/parser/__tests__/parser-table.test.ts
@@ -237,5 +237,69 @@ describe('MarkdownParser - Tables', () => {
       // Should NOT have cellStyle since it's mixed
       expect(mixedCell!.cellStyle).toBeUndefined();
     });
+
+    it('should show raw syntax when cell starts and ends with formatting delimiters but contains mixed content', () => {
+      const md = '| Col |\n|---|\n| **A** and **B** |\n| *A* and *B* |\n| `A` and `B` |\n| ~~A~~ and ~~B~~ |';
+      const result = parser.extractDecorations(md);
+      const cells = byType(result, 'tableCell');
+
+      const boldCell = cells.find((c) => c.replacement!.includes('**A**'));
+      expect(boldCell).toBeDefined();
+      expect(boldCell!.replacement).toContain('**');
+      expect(boldCell!.cellStyle).toBeUndefined();
+
+      const italicCell = cells.find((c) => c.replacement!.includes('*A*'));
+      expect(italicCell).toBeDefined();
+      expect(italicCell!.replacement).toContain('*');
+      expect(italicCell!.cellStyle).toBeUndefined();
+
+      const codeCell = cells.find((c) => c.replacement!.includes('`A`'));
+      expect(codeCell).toBeDefined();
+      expect(codeCell!.replacement).toContain('`');
+      expect(codeCell!.cellStyle).toBeUndefined();
+
+      const strikeCell = cells.find((c) => c.replacement!.includes('~~A~~'));
+      expect(strikeCell).toBeDefined();
+      expect(strikeCell!.replacement).toContain('~~');
+      expect(strikeCell!.cellStyle).toBeUndefined();
+    });
+
+    it('should not treat delimiter runs with inner whitespace as formatted cells', () => {
+      const md = '| Col |\n|---|\n| ** Not valid ** |';
+      const result = parser.extractDecorations(md);
+      const cells = byType(result, 'tableCell');
+      const cell = cells.find((c) => c.replacement!.includes('Not valid'));
+      expect(cell).toBeDefined();
+      expect(cell!.cellStyle).toBeUndefined();
+    });
+
+    it('should preserve backticks for inline code cells', () => {
+      const md = '| Col |\n|---|\n| `code only` |';
+      const result = parser.extractDecorations(md);
+      const cells = byType(result, 'tableCell');
+      const cell = cells.find((c) => c.replacement!.includes('code only'));
+      expect(cell).toBeDefined();
+      expect(cell!.replacement).toContain('`code only`');
+      expect(cell!.cellStyle).toBeUndefined();
+    });
+
+    it('should show raw syntax for nested partial formatting within bold or italic', () => {
+      const md = '| Col |\n|---|\n| **Bold and _italic_ inside** |';
+      const result = parser.extractDecorations(md);
+      const cells = byType(result, 'tableCell');
+      const cell = cells.find((c) => c.replacement!.includes('italic'));
+      expect(cell).toBeDefined();
+      expect(cell!.replacement).toContain('**');
+      expect(cell!.replacement).toContain('_');
+      expect(cell!.cellStyle).toBeUndefined();
+    });
+
+    it('should style whole-cell bold and italic when fully wrapped with combined delimiters', () => {
+      const md = '| Col |\n|---|\n| ***Bold and Italic*** |\n| **_Bold and Italic_** |';
+      const result = parser.extractDecorations(md);
+      const cells = byType(result, 'tableCell');
+      const cellsWithBoldItalic = cells.filter((c) => c.cellStyle?.fontWeight === 'bold' && c.cellStyle?.fontStyle === 'italic');
+      expect(cellsWithBoldItalic.length).toBe(2);
+    });
   });
 });

--- a/src/parser/core.ts
+++ b/src/parser/core.ts
@@ -1438,14 +1438,15 @@ export class MarkdownParser {
 
         const rawContent = text.substring(cellRangeStart, cellRangeEnd);
         const trimmedContent = rawContent.trim();
-        const cellStyle = this.detectCellStyle(trimmedContent);
         const colWidth = i < colWidths.length ? colWidths[i] : 3;
 
         // Whole-cell styled: extract clean text via AST + apply CSS
         // Mixed formatting: show raw syntax (VS Code can't partially style)
         // Plain / escaped: use AST extraction (handles \| → |, \\ → \)
         const astCell = i < row.children.length ? row.children[i] as TableCell : undefined;
-        const showRaw = !cellStyle && astCell && this.cellHasMixedFormatting(astCell);
+        const isMixed = astCell ? this.cellHasMixedFormatting(astCell) : false;
+        const cellStyle = isMixed ? undefined : this.detectCellStyle(trimmedContent);
+        const showRaw = isMixed;
         const displayContent = (astCell && !showRaw)
           ? this.extractCellPlainText(astCell)
           : trimmedContent;

--- a/src/parser/tables.ts
+++ b/src/parser/tables.ts
@@ -34,39 +34,67 @@ export function extractCellPlainText(cell: TableCell): string {
   return cell.children.map(walk).join('');
 }
 
+/**
+ * Determines whether a table cell contains mixed or partial formatting.
+ * Cells with mixed formatting cannot be styled with a single whole-cell CSS style
+ * and fall back to raw Markdown syntax to preserve visual formatting accuracy.
+ */
 export function cellHasMixedFormatting(cell: TableCell): boolean {
-  return cell.children.some((child) =>
-    child.type === 'strong' || child.type === 'emphasis' ||
-    child.type === 'delete' || child.type === 'inlineCode'
-  );
+  if (cell.children.length > 1) {
+    return cell.children.some((child) =>
+      child.type === 'strong' || child.type === 'emphasis' ||
+      child.type === 'delete' || child.type === 'inlineCode'
+    );
+  }
+  if (cell.children.length === 1) {
+    const child = cell.children[0];
+    if (child.type === 'inlineCode') {
+      return true;
+    }
+    // Check if the single formatted child has nested mixed formatting (e.g., **Bold and _italic_**)
+    if ('children' in child && Array.isArray((child as any).children)) {
+      const grandChildren = (child as any).children;
+      if (grandChildren.length > 1) {
+        return grandChildren.some((gc: any) =>
+          gc.type === 'strong' || gc.type === 'emphasis' ||
+          gc.type === 'delete' || gc.type === 'inlineCode'
+        );
+      }
+    }
+  }
+  return false;
 }
 
+/**
+ * Detects uniform whole-cell text styling from trimmed cell text.
+ * Enforces CommonMark flanking rules to prevent invalid whitespace from matching,
+ * and ensures nested or intermediate delimiter runs are not falsely treated as whole-cell styles.
+ */
 export function detectCellStyle(
   trimmed: string,
 ): { fontWeight?: string; fontStyle?: string; textDecoration?: string } | undefined {
   if (
-    (trimmed.startsWith('***') && trimmed.endsWith('***')) ||
-    (trimmed.startsWith('___') && trimmed.endsWith('___'))
+    (trimmed.startsWith('***') && trimmed.endsWith('***') && trimmed.length >= 8 && !trimmed.startsWith('*** ') && !trimmed.endsWith(' ***') && !trimmed.slice(3, -3).includes('***')) ||
+    (trimmed.startsWith('___') && trimmed.endsWith('___') && trimmed.length >= 8 && !trimmed.startsWith('___ ') && !trimmed.endsWith(' ___') && !trimmed.slice(3, -3).includes('___')) ||
+    (trimmed.startsWith('**_') && trimmed.endsWith('_**') && trimmed.length >= 8 && !trimmed.startsWith('**_ ') && !trimmed.endsWith(' _**')) ||
+    (trimmed.startsWith('_**') && trimmed.endsWith('**_') && trimmed.length >= 8 && !trimmed.startsWith('_** ') && !trimmed.endsWith(' **_'))
   ) {
     return { fontWeight: 'bold', fontStyle: 'italic' };
   }
   if (
-    (trimmed.startsWith('**') && trimmed.endsWith('**')) ||
-    (trimmed.startsWith('__') && trimmed.endsWith('__'))
+    (trimmed.startsWith('**') && trimmed.endsWith('**') && trimmed.length >= 6 && !trimmed.startsWith('** ') && !trimmed.endsWith(' **') && !trimmed.slice(2, -2).includes('**') && !trimmed.slice(2, -2).includes('_') && !trimmed.slice(2, -2).includes('`') && !trimmed.slice(2, -2).includes('~~')) ||
+    (trimmed.startsWith('__') && trimmed.endsWith('__') && trimmed.length >= 6 && !trimmed.startsWith('__ ') && !trimmed.endsWith(' __') && !trimmed.slice(2, -2).includes('__') && !trimmed.slice(2, -2).includes('*') && !trimmed.slice(2, -2).includes('`') && !trimmed.slice(2, -2).includes('~~'))
   ) {
     return { fontWeight: 'bold' };
   }
-  if (trimmed.startsWith('~~') && trimmed.endsWith('~~')) {
+  if (trimmed.startsWith('~~') && trimmed.endsWith('~~') && trimmed.length >= 6 && !trimmed.startsWith('~~ ') && !trimmed.endsWith(' ~~') && !trimmed.slice(2, -2).includes('~~')) {
     return { textDecoration: 'line-through' };
   }
   if (
-    (trimmed.startsWith('*') && trimmed.endsWith('*') && trimmed.length > 2) ||
-    (trimmed.startsWith('_') && trimmed.endsWith('_') && trimmed.length > 2)
+    (trimmed.startsWith('*') && trimmed.endsWith('*') && trimmed.length > 2 && !trimmed.startsWith('* ') && !trimmed.endsWith(' *') && !trimmed.slice(1, -1).includes('*') && !trimmed.slice(1, -1).includes('`') && !trimmed.slice(1, -1).includes('~~')) ||
+    (trimmed.startsWith('_') && trimmed.endsWith('_') && trimmed.length > 2 && !trimmed.startsWith('_ ') && !trimmed.endsWith(' _') && !trimmed.slice(1, -1).includes('_') && !trimmed.slice(1, -1).includes('`') && !trimmed.slice(1, -1).includes('~~'))
   ) {
     return { fontStyle: 'italic' };
-  }
-  if (trimmed.startsWith('`') && trimmed.endsWith('`') && trimmed.length > 2) {
-    return { fontWeight: 'normal' };
   }
   return undefined;
 }


### PR DESCRIPTION
> [!NOTE]
> - **Closes Issue**: #131
> - **Resolves Limitation**: #55 (Limitation item 3: Mixed inline formatting)

## Issue

In Markdown tables, cells containing mixed formatting or nested partial formatting (e.g. `| **A** and **B** |` or `| **Bold and _italic_ inside** |`) were erroneously classified as uniform whole-cell styles.

As a result:
1. The unformatted text between markers (e.g. `" and "`) was falsely rendered in bold.
2. In nested formatting (`**Bold and _italic_ inside**`), the nested `_italic_` formatting was stripped and flattened into plain bold.
3. Invalid markdown with spaces adjacent to asterisks (`** Text **`) was erroneously styled as bold text despite failing CommonMark left/right flanking rules.
4. Single inline code cells (` `code only` `) had their backticks stripped and styled with `{ fontWeight: 'normal' }`, making them visually indistinguishable from plain text.

## Reproduction / Try-out Snippet

```markdown
# Table Formatting Matrix

| Case | Content |
| :--- | :--- |
| Pure: Bold | **Only Bold** |
| Pure: Bold (Spaced Outside) |   **Bold Outer Space**   |
| Pure: Italic (*) | *Only Italic* |
| Pure: Italic (_) | _Only Italic_ |
| Pure: Bold Italic (***) | ***Bold and Italic*** |
| Pure: Bold Italic (**_) | **_Bold and Italic_** |
| Pure: Strikethrough | ~~Strike~~ |
| Code: Preserves Backticks | `code only` |
| Nested Partial: Fallback | **Bold and _italic_ inside** |
| Mixed: Bold + Normal + Bold | **A** and **B** |
| Mixed: Bold + Italic | **Bold** and *Italic* |
| Mixed: Start Only | **bold** and plain |
| Mixed: End Only | plain and **bold** |
| Invalid: Spaces inside stars | ** Not valid markdown ** |
| Literal: Math / Snake | 100 * 200 / my_var_name |
```

## Root Cause

1. **Naive String Prefix/Suffix Matching (`src/parser/tables.ts`)**:
`detectCellStyle` previously checked `trimmed.startsWith('**') && trimmed.endsWith('**')`. If a cell started and ended with formatting delimiters but had intermediate delimiters or normal text (e.g. `**A** and **B**`), it bypassed the mixed-formatting fallback and styled the entire cell.
2. **Missing Flanking Whitespace Check**:
CommonMark flanking rules prohibit whitespace immediately inside opening/closing delimiter runs. Without checking for inner whitespace (`!trimmed.startsWith('** ') && !trimmed.endsWith(' **')`), invalid syntax was styled as bold.
3. **Shallow AST Mixed Formatting Check**:
`cellHasMixedFormatting` only checked top-level `cell.children.length > 1`. A cell with `**Bold and _italic_ inside**` has a single outer `strong` node with multiple children (`text`, `emphasis`, `text`), avoiding the mixed formatting check and stripping nested styles.
4. **Stripping Backticks from Table Code**:
`detectCellStyle` returned `{ fontWeight: 'normal' }` for single inline code, removing backticks while providing no code background or styling in table cell replacements.

## Solution

1. **Flanking and Intermediate Delimiter Checks (`detectCellStyle`)**:
Enforced CommonMark whitespace rules and verified that the slice inside the delimiters does not contain intermediate or nested delimiters.
2. **Deep AST Inspection (`cellHasMixedFormatting`)**:
Inspects grandchildren when a single top-level formatted child exists, correctly triggering the mixed-formatting fallback for nested partial formatting.
3. **Preserve Code Backticks**:
Treated single inline code cells as raw syntax to preserve backtick visibility.
4. **Full Bold-Italic Combined Support**:
Added support for `**_..._**` and `_**...**_` for whole-cell bold italic rendering.

## Testing

- Added unit tests in `src/parser/__tests__/parser-table.test.ts` covering:
  - Mixed cells starting and ending with delimiters (`**A** and **B**`, `*A* and *B*`, etc.).
  - Nested partial formatting fallback (`**Bold and _italic_ inside**`).
  - Combined bold-italic full cell wrapping (`**_..._**`).
  - Whitespace-flanked invalid bold rejection.
  - Inline code backtick preservation.