### PR TITLE
fix(link-targets): support navigating to heading anchors across files

### DIFF
--- a/src/commands/navigate-to-anchor.ts
+++ b/src/commands/navigate-to-anchor.ts
@@ -6,7 +6,8 @@ async function navigateToAnchor(anchor: string, documentUri: string): Promise<vo
   const document = await vscode.workspace.openTextDocument(uri);
   const editor = await vscode.window.showTextDocument(document);
   const text = document.getText();
-  const lines = text.split('\n');
+  const lines = text.split(/\r?\n/);
+  const cleanAnchor = anchor.startsWith('#') ? anchor.substring(1) : anchor;
 
   for (let i = 0; i < lines.length; i++) {
     const headingMatch = lines[i].match(/^#+\s+(.+)$/);
@@ -14,7 +15,7 @@ async function navigateToAnchor(anchor: string, documentUri: string): Promise<vo
       continue;
     }
 
-    if (normalizeAnchorText(headingMatch[1]) !== anchor) {
+    if (normalizeAnchorText(headingMatch[1].trim()) !== cleanAnchor) {
       continue;
     }
 

--- a/src/link-targets.ts
+++ b/src/link-targets.ts
@@ -94,9 +94,17 @@ export function resolveLinkTarget(
     ? vscode.Uri.file(targetPath)
     : vscode.Uri.joinPath(documentUri, "..", targetPath);
 
+  if (fragment) {
+    return {
+      kind: "command",
+      command: "markdown-inline-editor.navigateToAnchor",
+      args: [fragment, baseUri.toString()],
+    };
+  }
+
   return {
     kind: "uri",
-    uri: fragment !== undefined ? baseUri.with({ fragment }) : baseUri,
+    uri: baseUri,
   };
 }
 

--- a/src/link-targets.ts
+++ b/src/link-targets.ts
@@ -30,7 +30,19 @@ export function resolveImageTarget(
     }
   }
 
-  return vscode.Uri.joinPath(documentUri, "..", trimmed);
+  let targetPath = trimmed;
+  let fragment: string | undefined;
+  const hashIdx = trimmed.indexOf("#");
+  if (hashIdx !== -1) {
+    targetPath = trimmed.substring(0, hashIdx);
+    fragment = trimmed.substring(hashIdx + 1);
+  }
+
+  const baseUri = targetPath.startsWith("/")
+    ? vscode.Uri.file(targetPath)
+    : vscode.Uri.joinPath(documentUri, "..", targetPath);
+
+  return fragment !== undefined ? baseUri.with({ fragment }) : baseUri;
 }
 
 export function resolveLinkTarget(
@@ -67,11 +79,25 @@ export function resolveLinkTarget(
     }
   }
 
-  if (trimmed.startsWith("/")) {
-    return { kind: "uri", uri: vscode.Uri.file(trimmed) };
+  // Split optional fragment/anchor (#heading) from the file path so that
+  // links like "./foo.md#test" navigate to the file and anchor instead of
+  // treating "#test" as part of the file name.
+  let targetPath = trimmed;
+  let fragment: string | undefined;
+  const hashIdx = trimmed.indexOf("#");
+  if (hashIdx !== -1) {
+    targetPath = trimmed.substring(0, hashIdx);
+    fragment = trimmed.substring(hashIdx + 1);
   }
 
-  return { kind: "uri", uri: vscode.Uri.joinPath(documentUri, "..", trimmed) };
+  const baseUri = targetPath.startsWith("/")
+    ? vscode.Uri.file(targetPath)
+    : vscode.Uri.joinPath(documentUri, "..", targetPath);
+
+  return {
+    kind: "uri",
+    uri: fragment !== undefined ? baseUri.with({ fragment }) : baseUri,
+  };
 }
 
 export function toCommandUri(command: string, args: unknown[]): vscode.Uri {

--- a/src/link-targets/__tests__/link-targets.test.ts
+++ b/src/link-targets/__tests__/link-targets.test.ts
@@ -62,20 +62,26 @@ describe("link-targets", () => {
       expect(result?.uri.toString()).toContain("relative.md");
     });
 
-    it("resolves relative paths with heading anchors without including anchor in file path", () => {
+    it("creates command targets for relative paths with heading anchors", () => {
       const result = resolveLinkTarget("./foo.md#test", documentUri as any);
-      expect(result?.kind).toBe("uri");
-      expect(result?.uri.path).toContain("foo.md");
-      expect(result?.uri.path).not.toContain("#test");
-      expect((result?.uri as any).fragment).toBe("test");
+      expect(result?.kind).toBe("command");
+      if (result?.kind === "command") {
+        expect(result.command).toBe("markdown-inline-editor.navigateToAnchor");
+        expect(result.args[0]).toBe("test");
+        expect(result.args[1]).toContain("foo.md");
+        expect(result.args[1]).not.toContain("#test");
+      }
     });
 
-    it("resolves absolute file paths with heading anchors", () => {
+    it("creates command targets for absolute file paths with heading anchors", () => {
       const result = resolveLinkTarget("/absolute/path/file.md#section", documentUri as any);
-      expect(result?.kind).toBe("uri");
-      expect(result?.uri.path).toContain("/absolute/path/file.md");
-      expect(result?.uri.path).not.toContain("#section");
-      expect((result?.uri as any).fragment).toBe("section");
+      expect(result?.kind).toBe("command");
+      if (result?.kind === "command") {
+        expect(result.command).toBe("markdown-inline-editor.navigateToAnchor");
+        expect(result.args[0]).toBe("section");
+        expect(result.args[1]).toContain("/absolute/path/file.md");
+        expect(result.args[1]).not.toContain("#section");
+      }
     });
   });
 

--- a/src/link-targets/__tests__/link-targets.test.ts
+++ b/src/link-targets/__tests__/link-targets.test.ts
@@ -61,6 +61,22 @@ describe("link-targets", () => {
       expect(result?.kind).toBe("uri");
       expect(result?.uri.toString()).toContain("relative.md");
     });
+
+    it("resolves relative paths with heading anchors without including anchor in file path", () => {
+      const result = resolveLinkTarget("./foo.md#test", documentUri as any);
+      expect(result?.kind).toBe("uri");
+      expect(result?.uri.path).toContain("foo.md");
+      expect(result?.uri.path).not.toContain("#test");
+      expect((result?.uri as any).fragment).toBe("test");
+    });
+
+    it("resolves absolute file paths with heading anchors", () => {
+      const result = resolveLinkTarget("/absolute/path/file.md#section", documentUri as any);
+      expect(result?.kind).toBe("uri");
+      expect(result?.uri.path).toContain("/absolute/path/file.md");
+      expect(result?.uri.path).not.toContain("#section");
+      expect((result?.uri as any).fragment).toBe("section");
+    });
   });
 
   describe("toCommandUri", () => {

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -68,24 +68,56 @@ export const Position = class {
 
 export const Uri = {
   parse: (value: string) => {
-    const schemeMatch = value.match(/^([^:]+):/);
+    const hashIndex = value.indexOf("#");
+    const baseValue = hashIndex !== -1 ? value.substring(0, hashIndex) : value;
+    const fragment = hashIndex !== -1 ? value.substring(hashIndex + 1) : "";
+    const schemeMatch = baseValue.match(/^([^:]+):/);
     const scheme = schemeMatch ? schemeMatch[1] : "file";
     return {
       toString: () => value,
       scheme: scheme,
+      fragment: fragment,
+      with: function (change: { fragment?: string; path?: string }) {
+        const newFrag = change.fragment !== undefined ? change.fragment : fragment;
+        const newBase = change.path ?? baseValue;
+        const fullStr = newFrag ? `${newBase}#${newFrag}` : newBase;
+        return Uri.parse(fullStr);
+      },
     };
   },
-  file: (path: string) => ({
-    toString: () => `file://${path}`,
-    scheme: "file",
-  }),
-  joinPath: (base: any, ...segments: string[]) => {
-    const basePath = base.toString().replace("file://", "");
-    const joined = [basePath, ...segments].join("/");
-    return {
-      toString: () => `file://${joined}`,
+  file: (path: string) => {
+    const uri = {
+      path: path,
       scheme: "file",
+      fragment: "",
+      toString: () => `file://${path}${uri.fragment ? "#" + uri.fragment : ""}`,
+      with: function (change: { fragment?: string; path?: string }) {
+        const newPath = change.path ?? uri.path;
+        const newFrag = change.fragment !== undefined ? change.fragment : uri.fragment;
+        const updated = Uri.file(newPath);
+        (updated as any).fragment = newFrag;
+        return updated;
+      },
     };
+    return uri;
+  },
+  joinPath: (base: any, ...segments: string[]) => {
+    const basePath = (base.path ?? base.toString().replace("file://", "")).split("#")[0];
+    const joined = [basePath, ...segments].join("/");
+    const uri = {
+      path: joined,
+      scheme: base.scheme ?? "file",
+      fragment: base.fragment ?? "",
+      toString: () => `file://${joined}${uri.fragment ? "#" + uri.fragment : ""}`,
+      with: function (change: { fragment?: string; path?: string }) {
+        const newPath = change.path ?? uri.path;
+        const newFrag = change.fragment !== undefined ? change.fragment : uri.fragment;
+        const updated = Uri.file(newPath);
+        (updated as any).fragment = newFrag;
+        return updated;
+      },
+    };
+    return uri;
   },
 };
 


### PR DESCRIPTION
> [!NOTE]
> - **Closes**: #140
>   - **File path resolution**: Separates the `#anchor` from the target path so VS Code opens the actual file.
>   - **Heading navigation & scrolling**: Routes file links with anchors to `navigateToAnchor` so the editor automatically scrolls to and centers the target heading.
>   - **CRLF line ending support**: Handles Windows `\r\n` line endings so headings in target files are reliably detected and matched.

## Reproduction

```md
[Link to file with heading](./foo.md#test)
```
- **Before**: Clicking the link threw `Unable to open 'foo.md#test'` because `#test` was treated as part of the file name. Even after fixing the path, VS Code's default open handler did not scroll to the heading, and CRLF line endings prevented heading matching.
- **After**: Opens the target file, matches the heading on all operating systems (LF & CRLF), and scrolls the target heading directly into view.

## Testing

- Unit tests added in `src/link-targets/__tests__/link-targets.test.ts` for relative and absolute paths with heading anchors.
- Verified manual click-navigation and scrolling across Markdown files.
