### PR TITLE
fix(decorator): scope diff view detection to editor instead of all visible windows

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,7 +1,7 @@
 import { DecorationOptions, Range, TextEditor, TextDocument, TextDocumentChangeEvent, window, TextEditorSelectionChangeKind, Memento } from 'vscode';
 import { DecorationRange, DecorationType, MermaidBlock, MathRegion, ScopeRange } from './parser';
 import { config } from './config';
-import { isDiffLikeUri, isDiffViewVisible } from './diff-context';
+import { isDiffLikeUri, isDiffViewVisible, isEditorInDiffView } from './diff-context';
 import { MarkdownParseCache } from './markdown-parse-cache';
 import {
   applyFilteredDecorations,
@@ -395,14 +395,7 @@ export class Decorator {
       return false;
     }
 
-    if (isDiffLikeUri(this.activeEditor.document.uri)) {
-      return true;
-    }
-
-    // For side-by-side diff views, check all visible editors
-    // If ANY visible editor is in a diff context, we're in a diff view
-    // This ensures both sides of the diff have decorations disabled
-    return isDiffViewVisible(window.visibleTextEditors);
+    return isEditorInDiffView(this.activeEditor, window.visibleTextEditors);
   }
 
   /**

--- a/src/diff-context.ts
+++ b/src/diff-context.ts
@@ -1,4 +1,4 @@
-import type * as vscode from 'vscode';
+import * as vscode from 'vscode';
 import { config } from './config';
 
 const DIFF_SCHEMES = new Set(['git', 'vscode-merge', 'vscode-diff']);
@@ -25,6 +25,54 @@ export function isDiffLikeUri(uri: vscode.Uri): boolean {
     if (fragment.includes('diff') || fragment.includes('merge')) {
       return true;
     }
+  }
+
+  return false;
+}
+
+/**
+ * Checks if a specific editor is part of a diff view.
+ *
+ * An editor is in a diff view if:
+ * 1. Its document URI is diff-like (e.g. git:, vscode-diff:), OR
+ * 2. It is the original/modified document in an active TabInputTextDiff, OR
+ * 3. It shares the same viewColumn with another visible editor that has a diff-like URI
+ *    (in VS Code, both sides of a side-by-side diff editor share the same viewColumn).
+ *
+ * This ensures that when a normal Markdown file is open in a split pane next to a diff,
+ * the normal Markdown file still displays decorations correctly.
+ */
+export function isEditorInDiffView(
+  targetEditor: vscode.TextEditor,
+  visibleEditors: readonly vscode.TextEditor[] = (vscode.window as any)?.visibleTextEditors ?? [],
+): boolean {
+  if (isDiffLikeUri(targetEditor.document.uri)) {
+    return true;
+  }
+
+  const tabGroups = (vscode.window as any)?.tabGroups?.all;
+  if (Array.isArray(tabGroups)) {
+    const targetUriStr = targetEditor.document.uri.toString();
+    for (const group of tabGroups) {
+      const activeTab = group?.activeTab;
+      const input = activeTab?.input;
+      if (input && typeof input === 'object') {
+        const originalUri = (input as any).original?.toString?.();
+        const modifiedUri = (input as any).modified?.toString?.();
+        if (targetUriStr === originalUri || targetUriStr === modifiedUri) {
+          return true;
+        }
+      }
+    }
+  }
+
+  if (targetEditor.viewColumn !== undefined) {
+    return visibleEditors.some(
+      (editor) =>
+        editor !== targetEditor &&
+        editor.viewColumn === targetEditor.viewColumn &&
+        isDiffLikeUri(editor.document.uri),
+    );
   }
 
   return false;

--- a/src/diff-context/__tests__/diff-context.test.ts
+++ b/src/diff-context/__tests__/diff-context.test.ts
@@ -1,5 +1,5 @@
 import { TextDocument, TextEditor, Uri, workspace } from '../../test/__mocks__/vscode';
-import { isDiffLikeUri, isDiffViewVisible, shouldSkipInDiffView } from '../../diff-context';
+import { isDiffLikeUri, isDiffViewVisible, isEditorInDiffView, shouldSkipInDiffView } from '../../diff-context';
 
 const mockGetConfiguration = vi.fn().mockReturnValue({
   get: vi.fn().mockReturnValue(false),
@@ -71,6 +71,38 @@ describe('diff-context', () => {
 
     it('returns false for empty editors array', () => {
       expect(isDiffViewVisible([])).toBe(false);
+    });
+  });
+
+  describe('isEditorInDiffView', () => {
+    it('returns true if the editor document has a diff-like URI', () => {
+      const diffEditor = new TextEditor(new TextDocument(Uri.parse('git:/file.md'), 'markdown', 1, ''), []);
+      expect(isEditorInDiffView(diffEditor as any, [diffEditor as any])).toBe(true);
+    });
+
+    it('returns true if another visible editor in the SAME viewColumn has a diff-like URI (side-by-side diff)', () => {
+      const leftDiff = new TextEditor(new TextDocument(Uri.parse('git:/file.md'), 'markdown', 1, ''), []);
+      (leftDiff as any).viewColumn = 1;
+      const rightWorking = new TextEditor(new TextDocument(Uri.file('/file.md'), 'markdown', 1, ''), []);
+      (rightWorking as any).viewColumn = 1;
+
+      expect(isEditorInDiffView(rightWorking as any, [leftDiff as any, rightWorking as any])).toBe(true);
+    });
+
+    it('returns false for normal file when diff editor is in a DIFFERENT viewColumn (split pane)', () => {
+      const diffEditor = new TextEditor(new TextDocument(Uri.parse('git:/file.md'), 'markdown', 1, ''), []);
+      (diffEditor as any).viewColumn = 1;
+      const normalMarkdown = new TextEditor(new TextDocument(Uri.file('/README.md'), 'markdown', 1, ''), []);
+      (normalMarkdown as any).viewColumn = 2;
+
+      expect(isEditorInDiffView(normalMarkdown as any, [diffEditor as any, normalMarkdown as any])).toBe(false);
+    });
+
+    it('returns false when no editors have diff-like URIs', () => {
+      const normalEditor = new TextEditor(new TextDocument(Uri.file('/README.md'), 'markdown', 1, ''), []);
+      (normalEditor as any).viewColumn = 1;
+
+      expect(isEditorInDiffView(normalEditor as any, [normalEditor as any])).toBe(false);
     });
   });
 


### PR DESCRIPTION
> [!NOTE]
> - **Closes**: #95
>   - **Isolated diff mode**: An open diff preview only disables decorations for itself, not for other open editors.
>   - **Fix split view**: Neighboring Markdown files now keep their formatting when a diff is open next to them.

## Reproduction

1. Open a diff preview from source control (or any diff view).
2. Open a normal `.md` file in a split editor pane next to it.
3. Focus into the `.md` file.

- **Before**: `isDiffEditor()` used `isDiffViewVisible(window.visibleTextEditors)`. Because the diff view was present anywhere among the visible editors, the normal `.md` file was mistakenly treated as a diff editor, stripping all its decorations and freezing it in raw mode.
- **After**: `isEditorInDiffView()` checks the active editor's document URI, its tab group, and whether it shares the same `viewColumn` with a diff editor (side-by-side diff). Normal Markdown files in other editor groups maintain their inline decorations uninterrupted.

## Testing

- Added unit tests in `src/diff-context/__tests__/diff-context.test.ts` covering:
  - Editor with direct diff-like URI returns `true`.
  - Both sides of a side-by-side diff sharing the same `viewColumn` return `true`.
  - Normal files in a different `viewColumn` (split pane) return `false`.
  - Normal files with no diffs return `false`.
- Manually verified in VS Code Extension Development Host side-by-side view.