### PR TITLE
Feat/highlight syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,12 @@
           "description": "Render LaTeX math inline ($...$ and $$...$$)",
           "markdownDescription": "Render LaTeX math inline ($...$ and $$...$$). When disabled, math delimiters are shown as plain text."
         },
+        "markdownInlineEditor.highlight.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Render highlighted text (==text==)",
+          "markdownDescription": "Render highlighted text (==text==) inline in Markdown documents. When disabled, == delimiters are shown as plain text."
+        },
         "markdownInlineEditor.orderedLists.autoNumber": {
           "type": "boolean",
           "default": true,
@@ -260,6 +266,18 @@
           "description": "Hex color for checkbox (unchecked and checked)",
           "format": "color",
           "markdownDescription": "Hex color for unchecked and checked checkbox symbols. Leave empty to use theme default."
+        },
+        "markdownInlineEditor.colors.highlight": {
+          "type": "string",
+          "description": "Hex color for highlighted text",
+          "format": "color",
+          "markdownDescription": "Hex color for highlighted text. Leave empty to use theme default."
+        },
+        "markdownInlineEditor.colors.highlightBackground": {
+          "type": "string",
+          "description": "Hex color for highlight background",
+          "format": "color",
+          "markdownDescription": "Hex color for highlight background overlay. Leave empty to use theme default (semi-transparent yellow)."
         }
       }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,13 @@ export const config = {
         .get<boolean>('math.enabled', true);
     },
   },
+  highlight: {
+    enabled(): boolean {
+      return vscode.workspace
+        .getConfiguration(SECTION)
+        .get<boolean>('highlight.enabled', true);
+    },
+  },
   orderedLists: {
     /** When true, ordered list markers are hidden and replaced with computed numbers (lazy `1.` numbering, etc.). When false, the source text is shown as written. */
     autoNumber(): boolean {
@@ -156,6 +163,12 @@ export const config = {
     },
     checkbox(): string | undefined {
       return getColorConfig('checkbox');
+    },
+    highlight(): string | undefined {
+      return getColorConfig('highlight');
+    },
+    highlightBackground(): string | undefined {
+      return getColorConfig('highlightBackground');
     },
   },
 } as const;

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -148,6 +148,44 @@ export function StrikethroughDecorationType() {
 }
 
 /**
+ * Creates a decoration type for highlighted text styling (==text==).
+ *
+ * Uses a theme-aware semi-transparent yellow background:
+ * - Dark themes: rgba(255, 214, 0, 0.28) for high contrast and clear white text readability
+ * - Light themes: rgba(255, 235, 59, 0.40) for classic highlighter aesthetic
+ *
+ * @param {string | ThemeColor | undefined} color - Optional hex or theme color for text
+ * @param {string | ThemeColor | undefined} backgroundColor - Optional hex or theme color for background overlay
+ * @returns {vscode.TextEditorDecorationType} A decoration type for highlighted text
+ */
+export function HighlightDecorationType(
+  color?: string | ThemeColor,
+  backgroundColor?: string | ThemeColor,
+) {
+  const isDark = isDarkTheme();
+  let bgColor: string | ThemeColor;
+  if (backgroundColor !== undefined) {
+    bgColor = backgroundColor;
+  } else {
+    bgColor = isDark
+      ? 'rgba(255, 214, 0, 0.28)'
+      : 'rgba(255, 235, 59, 0.40)';
+  }
+  const options: Record<string, unknown> = {};
+  if (typeof bgColor === 'string') {
+    // Apply background directly to text span to retain styling when delimiters are hidden
+    options.textDecoration = `none; background-color: ${bgColor}; border-radius: 3px;`;
+  } else {
+    options.backgroundColor = bgColor;
+    options.borderRadius = '3px';
+  }
+  if (color !== undefined) {
+    options.color = color;
+  }
+  return window.createTextEditorDecorationType(options);
+}
+
+/**
  * Creates a decoration type for inline code styling.
  *
  * Uses the editor background color with theme-aware brightness adjustment:

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -100,6 +100,8 @@ export class Decorator {
       getImageColor: () => config.colors.image(),
       getHorizontalRuleColor: () => config.colors.horizontalRule(),
       getCheckboxColor: () => config.colors.checkbox(),
+      getHighlightColor: () => config.colors.highlight(),
+      getHighlightBackgroundColor: () => config.colors.highlightBackground(),
     });
   }
 

--- a/src/decorator/__tests__/config-colors.test.ts
+++ b/src/decorator/__tests__/config-colors.test.ts
@@ -178,7 +178,7 @@ describe('config.colors', () => {
     const keys = [
       'heading1', 'heading2', 'heading3', 'heading4', 'heading5', 'heading6',
       'link', 'listMarker', 'inlineCode', 'inlineCodeBackground', 'emphasis', 'blockquote',
-      'image', 'horizontalRule', 'checkbox',
+      'image', 'horizontalRule', 'checkbox', 'highlight', 'highlightBackground',
     ] as const;
 
     it('each getter reads correct config key', () => {

--- a/src/decorator/__tests__/decoration-colors.test.ts
+++ b/src/decorator/__tests__/decoration-colors.test.ts
@@ -22,6 +22,7 @@ import {
   HorizontalRuleDecorationType,
   CheckboxUncheckedDecorationType,
   CheckboxCheckedDecorationType,
+  HighlightDecorationType,
 } from '../../decorations';
 
 describe('decoration creation with color (hex vs theme)', () => {
@@ -201,6 +202,41 @@ describe('decoration creation with color (hex vs theme)', () => {
     it('creates code decoration with ThemeColor background', () => {
       expect(CodeDecorationType('#e5c07b', new ThemeColor('editor.background'))).toBeDefined();
       expect(CodeDecorationType(undefined, new ThemeColor('editor.background'))).toBeDefined();
+    });
+  });
+
+  describe('HighlightDecorationType color parameters', () => {
+    beforeEach(() => {
+      resetTextEditorDecorationTypeOptionsCapture();
+    });
+
+    it('creates highlight decoration with default background and border radius in textDecoration', () => {
+      const dt = HighlightDecorationType();
+      expect(dt).toBeDefined();
+      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
+      expect(opts.textDecoration).toContain('background-color:');
+      expect(opts.textDecoration).toContain('border-radius: 3px;');
+      expect(opts.color).toBeUndefined();
+    });
+
+    it('creates highlight decoration with custom text color', () => {
+      HighlightDecorationType('#000000');
+      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
+      expect(opts.color).toBe('#000000');
+    });
+
+    it('creates highlight decoration with custom backgroundColor injected into textDecoration', () => {
+      HighlightDecorationType(undefined, '#ffeb3b');
+      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
+      expect(opts.textDecoration).toContain('background-color: #ffeb3b;');
+      expect(opts.textDecoration).toContain('border-radius: 3px;');
+    });
+
+    it('creates highlight decoration with ThemeColor background', () => {
+      HighlightDecorationType(undefined, new ThemeColor('editor.wordHighlightBackground'));
+      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
+      expect(opts.backgroundColor).toBeInstanceOf(ThemeColor);
+      expect(opts.borderRadius).toBe('3px');
     });
   });
 });

--- a/src/decorator/__tests__/decorator-filtering.test.ts
+++ b/src/decorator/__tests__/decorator-filtering.test.ts
@@ -598,6 +598,47 @@ describe('Marker decoration categorization', () => {
       expect(isMarkerDecorationType(type)).toBe(true);
     });
     expect(isMarkerDecorationType('bold')).toBe(false);
+    expect(isMarkerDecorationType('highlight')).toBe(false);
     expect(isMarkerDecorationType('link')).toBe(false);
+  });
+});
+
+describe('Highlight filtering (3-state)', () => {
+  const text = 'Line 0\nprefix ==highlight== suffix\nLine 2';
+  // 'prefix ' is 7 chars, so '==highlight==' is at line 1, offset 14..27
+  const decorations: DecorationRange[] = [
+    { startPos: 14, endPos: 16, type: 'hide' },
+    { startPos: 16, endPos: 25, type: 'highlight' },
+    { startPos: 25, endPos: 27, type: 'hide' },
+  ];
+  const scopes: Array<[number, number]> = [[14, 27]];
+
+  it('renders highlight and hides markers when cursor is on another line (Rendered state)', () => {
+    const selection = new Selection(new Position(0, 0), new Position(0, 0));
+    const filtered = filterDecorationsForSelection(text, decorations, scopes, selection);
+
+    expect(filtered.get('highlight')?.length).toBe(1);
+    expect(filtered.get('hide')?.length).toBe(2);
+    expect(filtered.has('ghostFaint')).toBe(false);
+  });
+
+  it('shows faint markers when cursor is on same line but outside highlight (Ghost state)', () => {
+    // line 1, character 0 (on "prefix", outside ==highlight==)
+    const selection = new Selection(new Position(1, 0), new Position(1, 0));
+    const filtered = filterDecorationsForSelection(text, decorations, scopes, selection);
+
+    expect(filtered.get('highlight')?.length).toBe(1);
+    expect(filtered.get('hide')?.length ?? 0).toBe(0);
+    expect(filtered.get('ghostFaint')?.length).toBe(2);
+  });
+
+  it('shows raw markers when cursor is inside highlight (Raw state)', () => {
+    // line 1, character 10 (inside "highlight")
+    const selection = new Selection(new Position(1, 10), new Position(1, 10));
+    const filtered = filterDecorationsForSelection(text, decorations, scopes, selection);
+
+    expect(filtered.get('highlight')?.length).toBe(1);
+    expect(filtered.get('hide')?.length ?? 0).toBe(0);
+    expect(filtered.get('ghostFaint')?.length ?? 0).toBe(0);
   });
 });

--- a/src/decorator/decoration-type-registry.ts
+++ b/src/decorator/decoration-type-registry.ts
@@ -7,6 +7,7 @@ import {
   ItalicDecorationType,
   BoldItalicDecorationType,
   StrikethroughDecorationType,
+  HighlightDecorationType,
   CodeDecorationType,
   CodeBlockDecorationType,
   CodeBlockLanguageDecorationType,
@@ -58,6 +59,8 @@ type RegistryOptions = {
   getImageColor?: () => string | undefined;
   getHorizontalRuleColor?: () => string | undefined;
   getCheckboxColor?: () => string | undefined;
+  getHighlightColor?: () => string | undefined;
+  getHighlightBackgroundColor?: () => string | undefined;
 };
 
 export class DecorationTypeRegistry {
@@ -68,6 +71,7 @@ export class DecorationTypeRegistry {
   private italicDecorationType!: TextEditorDecorationType;
   private boldItalicDecorationType!: TextEditorDecorationType;
   private strikethroughDecorationType!: TextEditorDecorationType;
+  private highlightDecorationType!: TextEditorDecorationType;
   private codeDecorationType!: TextEditorDecorationType;
   private codeBlockDecorationType!: TextEditorDecorationType;
   private codeBlockLanguageDecorationType!: TextEditorDecorationType;
@@ -107,6 +111,10 @@ export class DecorationTypeRegistry {
     this.italicDecorationType = ItalicDecorationType(this.options.getEmphasisColor?.());
     this.boldItalicDecorationType = BoldItalicDecorationType(this.options.getEmphasisColor?.());
     this.strikethroughDecorationType = StrikethroughDecorationType();
+    this.highlightDecorationType = HighlightDecorationType(
+      this.options.getHighlightColor?.(),
+      this.options.getHighlightBackgroundColor?.(),
+    );
     this.codeDecorationType = CodeDecorationType(this.options.getInlineCodeColor?.(), this.options.getInlineCodeBackgroundColor?.());
     this.codeBlockDecorationType = CodeBlockDecorationType();
     this.codeBlockLanguageDecorationType = CodeBlockLanguageDecorationType(this.options.getCodeBlockLanguageOpacity());
@@ -146,6 +154,7 @@ export class DecorationTypeRegistry {
       ['italic', this.italicDecorationType],
       ['boldItalic', this.boldItalicDecorationType],
       ['strikethrough', this.strikethroughDecorationType],
+      ['highlight', this.highlightDecorationType],
       ['code', this.codeDecorationType],
       ['codeBlock', this.codeBlockDecorationType],
       ['codeBlockLanguage', this.codeBlockLanguageDecorationType],
@@ -235,6 +244,12 @@ export class DecorationTypeRegistry {
     this.recreateDecorationType(this.horizontalRuleDecorationType, () => HorizontalRuleDecorationType(this.options.getHorizontalRuleColor?.()), (t) => { this.horizontalRuleDecorationType = t; }, 'horizontalRule');
     this.recreateDecorationType(this.checkboxUncheckedDecorationType, () => CheckboxUncheckedDecorationType(this.options.getCheckboxColor?.()), (t) => { this.checkboxUncheckedDecorationType = t; }, 'checkboxUnchecked');
     this.recreateDecorationType(this.checkboxCheckedDecorationType, () => CheckboxCheckedDecorationType(this.options.getCheckboxColor?.()), (t) => { this.checkboxCheckedDecorationType = t; }, 'checkboxChecked');
+    this.recreateDecorationType(
+      this.highlightDecorationType,
+      () => HighlightDecorationType(this.options.getHighlightColor?.(), this.options.getHighlightBackgroundColor?.()),
+      (t) => { this.highlightDecorationType = t; },
+      'highlight',
+    );
   }
 
   recreateGhostFaintDecorationType(): void {

--- a/src/parser/__tests__/parser-highlight.test.ts
+++ b/src/parser/__tests__/parser-highlight.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MarkdownParser } from '../core';
+import { config } from '../../config';
+
+describe('MarkdownParser - Highlight (==text==)', () => {
+  let parser: MarkdownParser;
+
+  beforeEach(async () => {
+    parser = await MarkdownParser.create();
+  });
+
+  describe('basic highlighting', () => {
+    it('should hide markers and style highlight text', () => {
+      const markdown = '==highlighted text==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      // Should have hide decorations for opening and closing ==
+      const hideDecorations = result.decorations.filter((d) => d.type === 'hide');
+      expect(hideDecorations.length).toBe(2);
+      expect(hideDecorations[0]).toEqual({
+        startPos: 0,
+        endPos: 2,
+        type: 'hide',
+      });
+      expect(hideDecorations[1]).toEqual({
+        startPos: 18,
+        endPos: 20,
+        type: 'hide',
+      });
+
+      // Should have highlight decoration for content
+      const highlightDecorations = result.decorations.filter((d) => d.type === 'highlight');
+      expect(highlightDecorations.length).toBe(1);
+      expect(highlightDecorations[0]).toEqual({
+        startPos: 2,
+        endPos: 18,
+        type: 'highlight',
+      });
+
+      // Should have highlight scope
+      const highlightScope = result.scopes.find((s) => s.kind === 'highlight');
+      expect(highlightScope).toBeDefined();
+      expect(highlightScope?.startPos).toBe(0);
+      expect(highlightScope?.endPos).toBe(20);
+    });
+
+    it('should handle highlight at start of line', () => {
+      const markdown = '==start== and more text';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.some((d) => d.type === 'highlight' && d.startPos === 2 && d.endPos === 7)).toBe(true);
+    });
+
+    it('should handle highlight in middle of text', () => {
+      const markdown = 'before ==middle== after';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.some((d) => d.type === 'highlight' && d.startPos === 9 && d.endPos === 15)).toBe(true);
+    });
+
+    it('should handle highlight at end of line', () => {
+      const markdown = 'some text ==end==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.some((d) => d.type === 'highlight' && d.startPos === 12 && d.endPos === 15)).toBe(true);
+    });
+
+    it('should handle multiple highlights on the same line', () => {
+      const markdown = '==first== and ==second==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      const highlightDecorations = result.decorations.filter((d) => d.type === 'highlight');
+      expect(highlightDecorations.length).toBe(2);
+      expect(highlightDecorations[0]).toEqual({ startPos: 2, endPos: 7, type: 'highlight' });
+      expect(highlightDecorations[1]).toEqual({ startPos: 16, endPos: 22, type: 'highlight' });
+    });
+  });
+
+  describe('nesting with other formatting', () => {
+    it('should handle bold inside highlight', () => {
+      const markdown = '==before **bold** after==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.some((d) => d.type === 'highlight')).toBe(true);
+      expect(result.decorations.some((d) => d.type === 'bold')).toBe(true);
+    });
+
+    it('should handle highlight inside bold', () => {
+      const markdown = '**before ==highlight== after**';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.some((d) => d.type === 'bold')).toBe(true);
+      expect(result.decorations.some((d) => d.type === 'highlight')).toBe(true);
+    });
+
+    it('should handle italic inside highlight', () => {
+      const markdown = '==some *italic* text==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.some((d) => d.type === 'highlight')).toBe(true);
+      expect(result.decorations.some((d) => d.type === 'italic')).toBe(true);
+    });
+
+    it('should handle link inside highlight', () => {
+      const markdown = '==visit [Example](https://example.com) today==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.some((d) => d.type === 'highlight')).toBe(true);
+      expect(result.decorations.some((d) => d.type === 'link')).toBe(true);
+    });
+
+    it('should handle inline code inside highlight', () => {
+      const markdown = '==run `git status` now==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.some((d) => d.type === 'highlight')).toBe(true);
+      expect(result.decorations.some((d) => d.type === 'code')).toBe(true);
+    });
+  });
+
+  describe('code block and inline code protection', () => {
+    it('should NOT parse highlights inside fenced code blocks', () => {
+      const markdown = '```\n==not highlighted==\n```';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      const highlights = result.decorations.filter((d) => d.type === 'highlight');
+      expect(highlights.length).toBe(0);
+    });
+
+    it('should NOT parse double equals inside inline code', () => {
+      const markdown = 'Check if `a == b` before proceeding';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      const highlights = result.decorations.filter((d) => d.type === 'highlight');
+      expect(highlights.length).toBe(0);
+    });
+  });
+
+  describe('flanking and syntax edge cases', () => {
+    it('should ignore empty highlight markers (====)', () => {
+      const markdown = 'Empty ==== here';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should ignore opening marker with trailing space (== text==)', () => {
+      const markdown = 'Invalid == text== here';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should ignore closing marker with leading space (==text ==)', () => {
+      const markdown = 'Invalid ==text == here';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should ignore escaped markers (\\==text\\==)', () => {
+      const markdown = 'Escaped \\==text\\== here';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should NOT match across blank lines / paragraph boundaries', () => {
+      const markdown = '==first paragraph\n\nsecond paragraph==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should ignore triple equals (===text===)', () => {
+      const markdown = '===triple equals===';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should ignore single equals (=text=)', () => {
+      const markdown = '=single equals=';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should decompose 4-equals run into closer and opener for adjacent highlights', () => {
+      const markdown = '==First====Second==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      const highlights = result.decorations.filter((d) => d.type === 'highlight');
+      expect(highlights.length).toBe(2);
+      expect(highlights[0]).toEqual({ startPos: 2, endPos: 7, type: 'highlight' });
+      expect(highlights[1]).toEqual({ startPos: 11, endPos: 17, type: 'highlight' });
+    });
+
+    it('should NOT match unclosed highlight across list item boundaries', () => {
+      const markdown = '- Item 1: ==unclosed highlight\n- Item 2: == invalid ==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should NOT match unclosed highlight across heading boundary', () => {
+      const markdown = '==unclosed text\n# Heading';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+
+    it('should ignore invalid spacing in list items', () => {
+      const markdown = '- == ungültig ==\n- ==ungültig ==\n- == ungültig==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+    });
+  });
+
+  describe('configuration toggle', () => {
+    it('should produce no highlight decorations when highlight.enabled is false', () => {
+      vi.spyOn(config.highlight, 'enabled').mockReturnValue(false);
+
+      const markdown = '==highlighted text==';
+      const result = parser.extractDecorationsWithScopes(markdown);
+
+      expect(result.decorations.filter((d) => d.type === 'highlight').length).toBe(0);
+      expect(result.decorations.filter((d) => d.type === 'hide').length).toBe(0);
+      expect(result.scopes.filter((s) => s.kind === 'highlight').length).toBe(0);
+
+      vi.restoreAllMocks();
+    });
+  });
+});

--- a/src/parser/core.ts
+++ b/src/parser/core.ts
@@ -28,6 +28,7 @@ import {
 import {
   processFrontmatter as processFrontmatterHelper,
 } from "./frontmatter";
+import { scanHighlightMarkers } from "./highlight";
 import {
   filterDecorationsInCodeBlocks as filterDecorationsInCodeBlocksHelper,
   scanMentionAndIssueRefs as scanMentionAndIssueRefsHelper,
@@ -184,6 +185,11 @@ export class MarkdownParser {
 
       // Handle edge cases: empty image alt text that remark doesn't parse as Image node
       this.handleEmptyImageAlt(normalizedText, decorations);
+
+      // Highlights: ==highlighted text==
+      if (config.highlight.enabled()) {
+        scanHighlightMarkers(normalizedText, decorations, scopes);
+      }
 
       // GitHub-style mentions and issue references (@username, @org/team, #123, @user/repo#456)
       if (config.mentions.enabled()) {

--- a/src/parser/highlight.ts
+++ b/src/parser/highlight.ts
@@ -1,0 +1,200 @@
+import type { DecorationRange, ScopeRange } from './types';
+import { addScope } from './common';
+
+/**
+ * Scans normalized markdown text for ==highlighted text== markers.
+ */
+export function scanHighlightMarkers(
+  text: string,
+  decorations: DecorationRange[],
+  scopes: ScopeRange[],
+): void {
+  if (!text || text.length < 5) {
+    return;
+  }
+
+  const excludedRanges = getExcludedRanges(scopes);
+  const inExcludedRange = (start: number, end: number): boolean =>
+    excludedRanges.some((range) => start < range.end && end > range.start);
+
+  const n = text.length;
+  let i = 0;
+
+  while (i < n - 3) {
+    if (text[i] === '=' && text[i + 1] === '=') {
+      const runLength = getEqualRunLength(text, i);
+
+      // Only even delimiter runs (2, 4) can open
+      if (runLength % 2 !== 0) {
+        i += runLength;
+        continue;
+      }
+
+      if (isEscaped(text, i) || inExcludedRange(i, i + 2)) {
+        i += runLength;
+        continue;
+      }
+
+      // Left-flanking: cannot be followed by '=', whitespace, or closing punctuation
+      const charAfterOpener = text[i + 2];
+      if (
+        charAfterOpener === '=' ||
+        /\s/.test(charAfterOpener) ||
+        /[.,;:)\]}]/.test(charAfterOpener)
+      ) {
+        i += runLength;
+        continue;
+      }
+
+      const inBlockquote = isLineInBlockquote(text, i);
+      let closerPos = -1;
+      let j = i + 2;
+
+      while (j < n - 1) {
+        if (isBlockBoundary(text, j, inBlockquote)) {
+          break;
+        }
+
+        if (text[j] === '=' && text[j + 1] === '=') {
+          const closerRun = getEqualRunLength(text, j);
+          if (closerRun % 2 === 0 && !isEscaped(text, j) && !inExcludedRange(j, j + 2)) {
+            // Right-flanking: cannot be preceded by whitespace
+            const charBeforeCloser = text[j - 1];
+            if (!/\s/.test(charBeforeCloser)) {
+              closerPos = j;
+              break;
+            }
+          }
+          j += closerRun;
+          continue;
+        }
+        j++;
+      }
+
+      if (closerPos !== -1) {
+        const start = i;
+        const end = closerPos + 2;
+        const contentStart = start + 2;
+        const contentEnd = closerPos;
+
+        if (contentStart < contentEnd) {
+          decorations.push({ startPos: start, endPos: contentStart, type: 'hide' });
+          decorations.push({ startPos: contentStart, endPos: contentEnd, type: 'highlight' });
+          decorations.push({ startPos: contentEnd, endPos: end, type: 'hide' });
+          addScope(scopes, start, end, 'highlight');
+        }
+
+        // For runs of 4 (==A====B==), advance by 2 so remaining 2 can open next highlight
+        i = closerPos + 2;
+        continue;
+      }
+    }
+
+    i++;
+  }
+}
+
+function isBlockBoundary(text: string, pos: number, inBlockquote: boolean): boolean {
+  if (text[pos] !== '\n' && (text[pos] !== '\r' || text[pos + 1] !== '\n')) {
+    return false;
+  }
+  let p = text[pos] === '\r' ? pos + 2 : pos + 1;
+  while (p < text.length && (text[p] === ' ' || text[p] === '\t')) {
+    p++;
+  }
+
+  // Blank line (paragraph break)
+  if (p >= text.length || text[p] === '\n' || text[p] === '\r') {
+    return true;
+  }
+
+  // Unordered list item (- , * , +)
+  if (
+    (text[p] === '-' || text[p] === '*' || text[p] === '+') &&
+    p + 1 < text.length &&
+    (text[p + 1] === ' ' || text[p + 1] === '\t')
+  ) {
+    return true;
+  }
+
+  // Ordered list item (1. , 1) )
+  if (/\d/.test(text[p])) {
+    let numEnd = p;
+    while (numEnd < text.length && /\d/.test(text[numEnd])) {
+      numEnd++;
+    }
+    if (
+      numEnd < text.length &&
+      (text[numEnd] === '.' || text[numEnd] === ')') &&
+      numEnd + 1 < text.length &&
+      (text[numEnd + 1] === ' ' || text[numEnd + 1] === '\t')
+    ) {
+      return true;
+    }
+  }
+
+  // Heading (1-6 '#' followed by space/tab)
+  if (text[p] === '#') {
+    let hEnd = p;
+    while (hEnd < text.length && text[hEnd] === '#') {
+      hEnd++;
+    }
+    if (hEnd - p <= 6 && hEnd < text.length && (text[hEnd] === ' ' || text[hEnd] === '\t')) {
+      return true;
+    }
+  }
+
+  // Blockquote entry from outside blockquote
+  if (text[p] === '>' && !inBlockquote) {
+    return true;
+  }
+
+  // Fenced code block or thematic break
+  if (p + 2 < text.length) {
+    const fence = text.slice(p, p + 3);
+    if (fence === '```' || fence === '~~~' || fence === '---') {
+      return true;
+    }
+  }
+
+  // Table row
+  return text[p] === '|';
+}
+
+function getEqualRunLength(text: string, pos: number): number {
+  let len = 0;
+  while (pos + len < text.length && text[pos + len] === '=') {
+    len++;
+  }
+  return len;
+}
+
+function isEscaped(text: string, index: number): boolean {
+  let backslashCount = 0;
+  let i = index - 1;
+  while (i >= 0 && text[i] === '\\') {
+    backslashCount++;
+    i--;
+  }
+  return backslashCount % 2 === 1;
+}
+
+function getExcludedRanges(scopes: ScopeRange[]): Array<{ start: number; end: number }> {
+  const out: Array<{ start: number; end: number }> = [];
+  for (const scope of scopes) {
+    if (scope.kind === 'codeBlock' || scope.kind === 'code' || scope.kind === 'frontmatter') {
+      out.push({ start: scope.startPos, end: scope.endPos });
+    }
+  }
+  out.sort((a, b) => a.start - b.start);
+  return out;
+}
+
+function isLineInBlockquote(text: string, pos: number): boolean {
+  const lineStart = pos === 0 ? 0 : text.lastIndexOf('\n', pos - 1) + 1;
+  let p = lineStart;
+  while (p < pos && (text[p] === ' ' || text[p] === '\t')) {
+    p++;
+  }
+  return p < pos && text[p] === '>';
+}

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -55,6 +55,7 @@ export type DecorationType =
   | "italic"
   | "boldItalic"
   | "strikethrough"
+  | "highlight"
   | "code"
   | "codeBlock"
   | "codeBlockLanguage"

--- a/src/registration/register-event-handlers.ts
+++ b/src/registration/register-event-handlers.ts
@@ -55,6 +55,11 @@ export function registerEventHandlers(
         decorator.recreateColorDependentTypes();
       }
 
+      if (event.affectsConfiguration('markdownInlineEditor.highlight.enabled')) {
+        decorator.clearCache();
+        decorator.updateDecorationsForSelection();
+      }
+
       if (event.affectsConfiguration('editor.fontSize') || event.affectsConfiguration('editor.lineHeight')) {
         decorator.clearMathDecorationCache();
       }


### PR DESCRIPTION
> [!NOTE]
> - **Closes**: #107
> - **Dependency**: Please review and merge PR #154 first. Table cell highlighting has been intentionally kept out of this PR to avoid merge conflicts - will be added once PR #&#8203;154 lands.

---

## Specifications

Fulfills the roadmap specification from `docs/features/todo.md` and `README.md`:

https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/blob/4572a5388e97becbecf4280ca33f60eff16f5c8d/docs/features/todo.md#L31-L39

https://github.com/SeardnaSchmid/markdown-inline-editor-vscode/blob/4572a5388e97becbecf4280ca33f60eff16f5c8d/README.md#L173

---

## Key Implementation Details

* **Syntax & Flanking Rules**:
  * Delimiters: `==text==`
  * Flanking compliance: strict left/right flanking without inner whitespace
  * Run decomposition: splits 4-equals runs (`====`) into closer and opener for adjacent highlights (`==A====B==`)
  * Boundary protection: terminates matching at blank lines, list items (`- `, `* `, `+ `, `1. `), headings (`#`), blockquotes, and code fences
  * Syntax isolation: ignores `==` in inline code spans, math formulas, and code blocks
  * Punctuation guard: prevents opening markers followed immediately by closing punctuation (e.g. `==,`)
* **Styling & Visibility**:
  * Decoration injection: applies background directly to text span via `textDecoration` to retain styling across all 3 visibility states (Rendered, Ghost, Raw)
  * Theme adaptive: default subtle yellow background
* **Configuration**:
  * `markdownInlineEditor.highlight.enabled` (default: `true`)
  * `markdownInlineEditor.colors.highlight` (text color)
  * `markdownInlineEditor.colors.highlightBackground` (background color)
* **Automated Tests**:
  * 24 unit tests covering syntax edge cases, adjacent runs, block boundaries, nesting (bold/italic/strikethrough/links/math), and configuration toggle; try-out block below.

---

## Open Points / Follow-ups (Full Table Support)

* **Current behavior**:
  * Table cells containing `==...==` currently fall back to raw text rendering.
* **Dependent on PR #154**:
  * PR #&#8203;154 refactors `detectCellStyle` and `cellHasMixedFormatting` in `src/parser/tables.ts`.
  * Merging PR #&#8203;154 first prevents merge conflicts in table parsing and column alignment logic.
* **Planned follow-up (Whole-cell highlighting in tables)**:
  * **Cell detection (`tables.ts`)**: Make `detectCellStyle` recognize whole-cell `==...==` and return `{isHighlight: true}`.
  * **Padding calculation (`core.ts`)**: Strip `==` delimiters from the cell display text so column widths and padding align cleanly.
  * **Decorator styling (`visibility-model.ts`)**: Apply the highlight background color to the cell's `before` pseudo-element when `isHighlight` is set.
  * **Unit tests (`parser-table.test.ts`)**: Add coverage for whole-cell highlight and mixed formatting fallback in table cells.

---

## Try-Out Snippet

````md
## 1. Basic Positions & Adjacent Delimiters

==Highlight at line start== followed by regular text.
Regular text with ==highlight in the middle== and regular text after.
Regular text followed by ==highlight at line end==
==AdjacentOne====AdjacentTwo==
==First====Second====Third==
Text before ==AdjacentA====AdjacentB== text after.

## 2. Nesting with Other Formatting

==Highlight with **bold**, *italic*, and ~~strikethrough~~ inside==
**Bold with ==highlight== inside**
*Italic with ==highlight== inside*
**Bold and *italic with ==nested highlight== inside* bold**
==**Combined bold and highlight**==
==Highlight with [link to VS Code](https://code.visualstudio.com) inside==
==Highlight with inline math $E = mc^2$ inside==
==Highlight with `inline code` inside==

## 3. Block Elements, Boundary Protection & ==Header Marking==

# Heading 1 with ==Highlight==

## H2 ==with Highlight==

### ==H3 with== Highlight

> Blockquote with ==highlight across
> two lines== inside blockquote

==Checkboxes and Lists==
- [ ] Task item with ==highlight==
- [x] Completed task with ==highlight==
- List item 1: ==unclosed highlight should stop at list boundary
- List item 2: ==properly highlighted item==
1. Ordered item 1: ==unclosed highlight should stop at item boundary
2. Ordered item 2: ==properly highlighted item==
==Highlight across
soft line breaks within paragraph==

## 4. Syntax & Negative Protection (Should NOT highlight)

- Inner space after opener: == invalid==
- Inner space before closer: ==invalid ==
- Inner space both sides: == invalid ==
- Empty run: ====
- Triple equals: ===not highlighted===
- Single equals: =not highlighted=
- Escaped markers: \==this text is escaped\==
- Equality operators: a == b && c == d
==Unclosed highlight before blank line

Paragraph after blank line should not be affected==

```javascript
// In code blocks ==text== must never be highlighted
const a == b;
const message = "==no highlight==";
```
````

### Preview
<kbd><img width="500" alt="MD Highlight - Try-Out Preview" src="https://github.com/user-attachments/assets/a7d4acb0-4633-442a-83fb-abd2b7d6bc3d" /></kbd>
