### PR TITLE
fix(decorator): draw the checkbox on a real character so it can be clicked

### DIFF
--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -10,8 +10,6 @@ const BRIGHTNESS_OVERLAY_OPACITY = 0.1;
 const CHECKBOX_BOX_SIZE = '1em';
 /** Gap between checkbox and adjacent text. */
 const CHECKBOX_GAP_SIZE = '0.6em';
-/** Left padding applied after the checkbox. */
-const CHECKBOX_PADDING = '0.2em';
 
 /**
  * Determines if the current theme is dark or high contrast.
@@ -482,27 +480,40 @@ export function HorizontalRuleDecorationType(color?: string | ThemeColor) {
 }
 
 /**
- * Creates the before block options for checkbox decorations.
- * Shared between CheckboxUncheckedDecorationType and CheckboxCheckedDecorationType.
+ * Shared box styling for the checkbox decorations.
+ *
+ * The box is drawn on the checkbox's state character (the space or the `x`)
+ * rather than as a pseudo-element over the whole `- [ ]` run. VS Code's mouse
+ * hit testing walks real characters, and it skips over a run that a decoration
+ * has collapsed — a box painted with `::before` on hidden text therefore never
+ * receives a click at all, which is why toggling used to do nothing unless the
+ * click happened to land just outside the box.
+ *
+ * @param resolvedColor - Border colour for the box
  */
-function createCheckboxBeforeOptions(resolvedColor: string | ThemeColor) {
+function checkboxBoxOptions(resolvedColor: string | ThemeColor) {
   return {
-    contentText: ' ',
+    // `color` feeds currentColor for the border drawn below.
     color: resolvedColor,
-    height: CHECKBOX_BOX_SIZE,
-    width: CHECKBOX_BOX_SIZE,
-    border: '1px solid',
-    borderColor: resolvedColor,
-    // Negative margin-right pulls the 'after' element inside the box border.
-    textDecoration: `display: inline-block; box-sizing: border-box; vertical-align: middle; margin-right: -${CHECKBOX_BOX_SIZE}; cursor: pointer;`,
+    // Inline decorations never emit the border properties — only whole-line
+    // ones do — so the box is drawn through the textDecoration escape hatch
+    // the rest of this file already uses.
+    textDecoration: 'none;'
+      + ' display: inline-block; box-sizing: border-box; text-align: center;'
+      + ` width: ${CHECKBOX_BOX_SIZE}; height: ${CHECKBOX_BOX_SIZE}; line-height: 1;`
+      + ' border: 1px solid currentColor; border-radius: 2px;'
+      + ` vertical-align: middle; margin-right: ${CHECKBOX_GAP_SIZE}; cursor: pointer;`,
   };
 }
 
 /**
  * Creates a decoration type for unchecked checkbox styling.
  *
- * Replaces [ ] with an empty checkbox.
- * Click inside the brackets to toggle.
+ * Draws an empty box over the checkbox's state character. The box deliberately
+ * sits on that real character rather than in a `before` attachment: VS Code's
+ * mouse hit testing walks real characters and skips both collapsed runs and
+ * attachment spans, so a box drawn as an attachment never receives a click —
+ * which is why toggling used to do nothing.
  *
  * @param {string | ThemeColor | undefined} color - Optional hex or theme color; when undefined uses editor.foreground
  * @returns {vscode.TextEditorDecorationType} A decoration type for unchecked checkboxes
@@ -510,29 +521,15 @@ function createCheckboxBeforeOptions(resolvedColor: string | ThemeColor) {
 export function CheckboxUncheckedDecorationType(color?: string | ThemeColor) {
   const resolvedColor = color ?? new ThemeColor('editor.foreground');
 
-  return window.createTextEditorDecorationType({
-    textDecoration: 'none; display: none;',
-    before: createCheckboxBeforeOptions(resolvedColor),
-    after: {
-      contentText: ' ',
-      color: resolvedColor,
-      textDecoration: `
-        display: inline-block;
-        position: relative;
-        width: ${CHECKBOX_BOX_SIZE};
-        cursor: pointer;
-        margin-right: ${CHECKBOX_GAP_SIZE};
-        margin-left: ${CHECKBOX_PADDING};
-      `
-    }
-  });
+  return window.createTextEditorDecorationType(checkboxBoxOptions(resolvedColor));
 }
 
 /**
  * Creates a decoration type for checked checkbox styling.
  *
- * Replaces [x] or [X] with a checked checkbox.
- * Click inside the brackets to toggle.
+ * The same box, with the `x` of `[x]` left visible inside it. A tick drawn as a
+ * `before` attachment would cover the middle of the box and make exactly that
+ * part unclickable, so the state character does the job instead.
  *
  * @param {string | ThemeColor | undefined} color - Optional hex or theme color; when undefined uses editor.foreground
  * @returns {vscode.TextEditorDecorationType} A decoration type for checked checkboxes
@@ -540,21 +537,18 @@ export function CheckboxUncheckedDecorationType(color?: string | ThemeColor) {
 export function CheckboxCheckedDecorationType(color?: string | ThemeColor) {
   const resolvedColor = color ?? new ThemeColor('editor.foreground');
 
+  return window.createTextEditorDecorationType(checkboxBoxOptions(resolvedColor));
+}
+
+/**
+ * Creates a decoration type that hides the brackets and list marker around a
+ * rendered checkbox, leaving only the box itself visible.
+ *
+ * @returns {vscode.TextEditorDecorationType} A decoration type hiding checkbox syntax
+ */
+export function CheckboxBracketDecorationType() {
   return window.createTextEditorDecorationType({
     textDecoration: 'none; display: none;',
-    before: createCheckboxBeforeOptions(resolvedColor),
-    after: {
-      contentText: '✔',
-      color: resolvedColor,
-      textDecoration: `
-        display: inline-block;
-        position: relative;
-        width: ${CHECKBOX_BOX_SIZE};
-        cursor: pointer;
-        margin-right: ${CHECKBOX_GAP_SIZE};
-        margin-left: ${CHECKBOX_PADDING};
-      `
-    }
   });
 }
 

--- a/src/decorator/__tests__/checkbox-toggle.test.ts
+++ b/src/decorator/__tests__/checkbox-toggle.test.ts
@@ -117,4 +117,68 @@ describe('handleCheckboxClick', () => {
       expect(edits[0].newText).toBe('x');
     });
   });
+
+  // The rendered box replaces the whole task-list prefix, not just "[ ]".
+  // The parser emits the decoration from markerStart for bullet lists
+  // (see parser/list-quote.ts), and that whole span is display:none, so a click
+  // on the box lands on the decoration start — the list marker, not the bracket.
+  describe('click lands on the list marker (rendered box hit area)', () => {
+    it('toggles when the cursor lands on the bullet marker at char 0', () => {
+      const editor = makeEditor('- [ ] task', 0);
+      expect(handleCheckboxClick(editor as any)).toBe(true);
+      const edit = (workspace.applyEdit as Mock).mock.calls[0][0] as WorkspaceEdit;
+      const edits = edit.getEdits();
+      expect(edits[0].range.start.character).toBe(3); // bracketStart(2) + 1
+      expect(edits[0].newText).toBe('x');
+    });
+
+    it('toggles when the cursor lands on the space between marker and bracket', () => {
+      const editor = makeEditor('- [ ] task', 1);
+      expect(handleCheckboxClick(editor as any)).toBe(true);
+      expect((workspace.applyEdit as Mock).mock.calls[0][0].getEdits()[0].newText).toBe('x');
+    });
+
+    it('toggles a checked box clicked at the marker', () => {
+      const editor = makeEditor('* [x] done', 0);
+      expect(handleCheckboxClick(editor as any)).toBe(true);
+      expect((workspace.applyEdit as Mock).mock.calls[0][0].getEdits()[0].newText).toBe(' ');
+    });
+
+    it('toggles an indented nested item clicked at its marker', () => {
+      //   "  - [ ] nested" — marker at char 2, bracket at char 4
+      const editor = makeEditor('  - [ ] nested', 2);
+      expect(handleCheckboxClick(editor as any)).toBe(true);
+      const edits = (workspace.applyEdit as Mock).mock.calls[0][0].getEdits();
+      expect(edits[0].range.start.character).toBe(5); // bracketStart(4) + 1
+    });
+
+    it('does not toggle from the indent whitespace before the marker', () => {
+      // Ordered lists keep the decoration at the bracket, and leading indent is
+      // never part of the rendered box for either list kind.
+      const editor = makeEditor('  - [ ] nested', 0);
+      expect(handleCheckboxClick(editor as any)).toBe(false);
+      expect(workspace.applyEdit).not.toHaveBeenCalled();
+    });
+
+    it('does not extend the hit area to the marker for ordered lists', () => {
+      // parser/list-quote.ts anchors ordered-list checkboxes at checkboxStart,
+      // so "1." stays clickable text rather than part of the box.
+      const editor = makeEditor('1. [ ] task', 0);
+      expect(handleCheckboxClick(editor as any)).toBe(false);
+      expect(workspace.applyEdit).not.toHaveBeenCalled();
+    });
+
+    it('toggles an ordered-list checkbox clicked on its bracket', () => {
+      const editor = makeEditor('1. [ ] task', 3);
+      expect(handleCheckboxClick(editor as any)).toBe(true);
+      expect((workspace.applyEdit as Mock).mock.calls[0][0].getEdits()[0].newText).toBe('x');
+    });
+
+    it('leaves a non-task bracket pair on a list line alone', () => {
+      // "- see [ ] below" is not a task item: the bracket is not the first token.
+      const editor = makeEditor('- see [ ] below', 0);
+      expect(handleCheckboxClick(editor as any)).toBe(false);
+      expect(workspace.applyEdit).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/decorator/__tests__/decoration-colors.test.ts
+++ b/src/decorator/__tests__/decoration-colors.test.ts
@@ -22,6 +22,7 @@ import {
   HorizontalRuleDecorationType,
   CheckboxUncheckedDecorationType,
   CheckboxCheckedDecorationType,
+  CheckboxBracketDecorationType,
 } from '../../decorations';
 
 describe('decoration creation with color (hex vs theme)', () => {
@@ -139,44 +140,38 @@ describe('decoration creation with color (hex vs theme)', () => {
       expect(CheckboxCheckedDecorationType()).toBeDefined();
     });
 
-    it('CheckboxCheckedDecorationType has after block with contentText "✔"', () => {
-      resetTextEditorDecorationTypeOptionsCapture();
-      CheckboxCheckedDecorationType();
-      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
-      expect(opts.after).toBeDefined();
-      expect((opts.after as Record<string, unknown>).contentText).toBe('✔');
-    });
-
-    it('CheckboxCheckedDecorationType after block includes display: inline-block in textDecoration', () => {
-      resetTextEditorDecorationTypeOptionsCapture();
-      CheckboxCheckedDecorationType();
-      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
-      const after = opts.after as Record<string, unknown>;
-      expect(after.textDecoration).toContain('display: inline-block');
-    });
-
-    it('CheckboxCheckedDecorationType after block includes cursor: pointer in textDecoration', () => {
-      resetTextEditorDecorationTypeOptionsCapture();
-      CheckboxCheckedDecorationType();
-      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
-      const after = opts.after as Record<string, unknown>;
-      expect(after.textDecoration).toContain('cursor: pointer');
-    });
-
-    it('CheckboxUncheckedDecorationType after block has space contentText', () => {
+    // The box must be styled on the decorated character itself. VS Code's mouse
+    // hit testing walks real characters and skips a collapsed run, so a box
+    // painted into a ::before pseudo-element never receives a click.
+    // The box must be styled on the decorated character itself. VS Code's mouse
+    // hit testing walks real characters and skips attachment spans, so a box
+    // drawn into a ::before never receives a click.
+    it('CheckboxUncheckedDecorationType styles the character itself, not an attachment', () => {
       resetTextEditorDecorationTypeOptionsCapture();
       CheckboxUncheckedDecorationType();
       const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
-      expect(opts.after).toBeDefined();
-      expect((opts.after as Record<string, unknown>).contentText).toBe(' ');
+      expect(opts.before).toBeUndefined();
+      expect(opts.after).toBeUndefined();
+      expect(opts.textDecoration).toContain('border: 1px solid currentColor');
+      expect(opts.textDecoration).toContain('display: inline-block');
+      expect(opts.textDecoration).toContain('cursor: pointer');
     });
 
-    it('CheckboxUncheckedDecorationType after block includes cursor: pointer in textDecoration', () => {
+    it('CheckboxCheckedDecorationType draws the same clickable box, tick-free', () => {
       resetTextEditorDecorationTypeOptionsCapture();
-      CheckboxUncheckedDecorationType();
+      CheckboxCheckedDecorationType();
       const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
-      const after = opts.after as Record<string, unknown>;
-      expect(after.textDecoration).toContain('cursor: pointer');
+      // A tick attachment would cover the middle of the box and block clicks there.
+      expect(opts.before).toBeUndefined();
+      expect(opts.textDecoration).toContain('border: 1px solid currentColor');
+      expect(opts.textDecoration).toContain('cursor: pointer');
+    });
+
+    it('CheckboxBracketDecorationType hides the surrounding syntax', () => {
+      resetTextEditorDecorationTypeOptionsCapture();
+      CheckboxBracketDecorationType();
+      const opts = getLastTextEditorDecorationTypeOptions() as Record<string, unknown>;
+      expect(opts.textDecoration).toContain('display: none');
     });
   });
 

--- a/src/decorator/checkbox-toggle.ts
+++ b/src/decorator/checkbox-toggle.ts
@@ -1,5 +1,32 @@
 import { Position, Range, Selection, WorkspaceEdit, type TextEditor, workspace } from 'vscode';
 
+/** Task-list prefix: indent, bullet or ordered marker, spacing, then a checkbox. */
+const TASK_PREFIX_REGEX = /^(\s*)([-*+]|\d+[.)])(\s+)(?=\[[ xX]\])/;
+
+/**
+ * Locates the rendered checkbox box on a task-list line.
+ *
+ * The parser emits the checkbox decoration from the list marker for bullet
+ * lists and from the bracket for ordered lists (parser/list-quote.ts), and that
+ * whole span is hidden behind the drawn box. A click on the box therefore lands
+ * on the decoration start, so the hit area has to start there too — otherwise
+ * clicking a bullet task item does nothing.
+ *
+ * @returns the decoration start and its bracket offset, or null when the line
+ *   is not a task item
+ */
+function findTaskCheckbox(lineText: string): { decorationStart: number; bracketStart: number } | null {
+  const match = TASK_PREFIX_REGEX.exec(lineText);
+  if (!match) return null;
+
+  const [prefix, indent, marker] = match;
+  const isOrderedList = /\d/.test(marker);
+  return {
+    decorationStart: isOrderedList ? prefix.length : indent.length,
+    bracketStart: prefix.length,
+  };
+}
+
 /**
  * Handles checkbox toggle when user clicks inside [ ] or [x].
  * Detects if cursor is positioned inside a checkbox and toggles it.
@@ -15,6 +42,7 @@ export function handleCheckboxClick(editor: TextEditor): boolean {
   const document = editor.document;
   const line = document.lineAt(selection.active.line);
   const cursorChar = selection.active.character;
+  const taskCheckbox = findTaskCheckbox(line.text);
 
   // Find checkbox pattern on this line: [ ] or [x] or [X]
   const checkboxRegex = /\[([ xX])\]/g;
@@ -24,9 +52,14 @@ export function handleCheckboxClick(editor: TextEditor): boolean {
     const bracketStart = match.index;
     const bracketEnd = match.index + 3; // [ ] is 3 chars
 
+    // The task-list box swallows the marker before it, so widen the hit area to
+    // the decoration start for that first checkbox only.
+    const hitStart = taskCheckbox?.bracketStart === bracketStart
+      ? taskCheckbox.decorationStart
+      : bracketStart;
+
     // Check if cursor is on or inside the checkbox [ ] range
-    // Include bracketStart because clicking the ☐ decoration lands cursor there
-    if (cursorChar >= bracketStart && cursorChar <= bracketEnd) {
+    if (cursorChar >= hitStart && cursorChar <= bracketEnd) {
       const currentState = match[1];
       const newState = currentState === ' ' ? 'x' : ' ';
 

--- a/src/decorator/decoration-categories.ts
+++ b/src/decorator/decoration-categories.ts
@@ -15,6 +15,7 @@ const markerDecorationTypes: ReadonlySet<DecorationType> = new Set<DecorationTyp
   'orderedListItem',
   'checkboxUnchecked',
   'checkboxChecked',
+  'checkboxBracket',
   'horizontalRule',
   'frontmatterDelimiter',
   'tablePipe',

--- a/src/decorator/decoration-type-registry.ts
+++ b/src/decorator/decoration-type-registry.ts
@@ -28,6 +28,7 @@ import {
   HorizontalRuleDecorationType,
   CheckboxUncheckedDecorationType,
   CheckboxCheckedDecorationType,
+  CheckboxBracketDecorationType,
   FrontmatterDecorationType,
   FrontmatterDelimiterDecorationType,
   EmojiDecorationType,
@@ -89,6 +90,7 @@ export class DecorationTypeRegistry {
   private horizontalRuleDecorationType!: TextEditorDecorationType;
   private checkboxUncheckedDecorationType!: TextEditorDecorationType;
   private checkboxCheckedDecorationType!: TextEditorDecorationType;
+  private checkboxBracketDecorationType!: TextEditorDecorationType;
   private frontmatterDecorationType!: TextEditorDecorationType;
   private frontmatterDelimiterDecorationType!: TextEditorDecorationType;
   private emojiDecorationType!: TextEditorDecorationType;
@@ -131,6 +133,7 @@ export class DecorationTypeRegistry {
     this.horizontalRuleDecorationType = HorizontalRuleDecorationType(this.options.getHorizontalRuleColor?.());
     this.checkboxUncheckedDecorationType = CheckboxUncheckedDecorationType(this.options.getCheckboxColor?.());
     this.checkboxCheckedDecorationType = CheckboxCheckedDecorationType(this.options.getCheckboxColor?.());
+    this.checkboxBracketDecorationType = CheckboxBracketDecorationType();
     this.frontmatterDecorationType = FrontmatterDecorationType();
     this.frontmatterDelimiterDecorationType = FrontmatterDelimiterDecorationType(this.options.getFrontmatterDelimiterOpacity());
     this.emojiDecorationType = EmojiDecorationType();
@@ -166,6 +169,7 @@ export class DecorationTypeRegistry {
       ['horizontalRule', this.horizontalRuleDecorationType],
       ['checkboxUnchecked', this.checkboxUncheckedDecorationType],
       ['checkboxChecked', this.checkboxCheckedDecorationType],
+      ['checkboxBracket', this.checkboxBracketDecorationType],
       ['frontmatter', this.frontmatterDecorationType],
       ['frontmatterDelimiter', this.frontmatterDelimiterDecorationType],
       ['emoji', this.emojiDecorationType],

--- a/src/decorator/visibility-model.ts
+++ b/src/decorator/visibility-model.ts
@@ -45,8 +45,13 @@ export function filterDecorationsForEditor(
     'blockquote',
     'listItem',
     'orderedListItem',
+  ]);
+  // A rendered checkbox is three decorations over one run of text; they reveal
+  // as a unit off the shared 'checkbox' scope so it never shows half-rendered.
+  const checkboxTypes = new Set<DecorationType>([
     'checkboxUnchecked',
     'checkboxChecked',
+    'checkboxBracket',
   ]);
   const headingTypes = new Set<DecorationType>([
     'heading',
@@ -117,6 +122,17 @@ export function filterDecorationsForEditor(
           selectionOverlayRanges.push(intersection);
         }
       }
+    }
+
+    if (checkboxTypes.has(decoration.type)) {
+      if (rangeIntersectsAny(range, rawRanges) || selectionOrCursorOverlaps(range)) {
+        // Raw state: show the actual `- [ ]` characters
+        continue;
+      }
+      const ranges = filtered.get(decoration.type) || [];
+      ranges.push(range);
+      filtered.set(decoration.type, ranges);
+      continue;
     }
 
     if (selectionOnlyMarkerTypes.has(decoration.type)) {

--- a/src/parser/__tests__/parser-checkbox.test.ts
+++ b/src/parser/__tests__/parser-checkbox.test.ts
@@ -12,13 +12,12 @@ describe('MarkdownParser - Checkbox/Task List', () => {
       const markdown = '- [ ] Task item';
       const result = parser.extractDecorations(markdown);
 
-      // No listItem when checkbox is present; single checkbox covers marker + "[ ]"
+      // No listItem when a checkbox is present. The box is drawn on the state
+      // character alone so it is clickable; "- [" and "]" are hidden around it.
       expect(result.filter(d => d.type === 'listItem').length).toBe(0);
-      expect(result).toContainEqual({
-        startPos: 0,
-        endPos: 5,
-        type: 'checkboxUnchecked'
-      });
+      expect(result).toContainEqual({ startPos: 3, endPos: 4, type: 'checkboxUnchecked' });
+      expect(result).toContainEqual({ startPos: 0, endPos: 3, type: 'checkboxBracket' });
+      expect(result).toContainEqual({ startPos: 4, endPos: 5, type: 'checkboxBracket' });
     });
 
     it('should detect unchecked checkbox with asterisk marker', () => {
@@ -26,11 +25,7 @@ describe('MarkdownParser - Checkbox/Task List', () => {
       const result = parser.extractDecorations(markdown);
 
       expect(result.filter(d => d.type === 'listItem').length).toBe(0);
-      expect(result).toContainEqual({
-        startPos: 0,
-        endPos: 5,
-        type: 'checkboxUnchecked'
-      });
+      expect(result).toContainEqual({ startPos: 3, endPos: 4, type: 'checkboxUnchecked' });
     });
 
     it('should detect unchecked checkbox with plus marker', () => {
@@ -38,11 +33,7 @@ describe('MarkdownParser - Checkbox/Task List', () => {
       const result = parser.extractDecorations(markdown);
 
       expect(result.filter(d => d.type === 'listItem').length).toBe(0);
-      expect(result).toContainEqual({
-        startPos: 0,
-        endPos: 5,
-        type: 'checkboxUnchecked'
-      });
+      expect(result).toContainEqual({ startPos: 3, endPos: 4, type: 'checkboxUnchecked' });
     });
   });
 
@@ -52,11 +43,7 @@ describe('MarkdownParser - Checkbox/Task List', () => {
       const result = parser.extractDecorations(markdown);
 
       expect(result.filter(d => d.type === 'listItem').length).toBe(0);
-      expect(result).toContainEqual({
-        startPos: 0,
-        endPos: 5,
-        type: 'checkboxChecked'
-      });
+      expect(result).toContainEqual({ startPos: 3, endPos: 4, type: 'checkboxChecked' });
     });
 
     it('should detect checked checkbox with uppercase X', () => {
@@ -64,11 +51,7 @@ describe('MarkdownParser - Checkbox/Task List', () => {
       const result = parser.extractDecorations(markdown);
 
       expect(result.filter(d => d.type === 'listItem').length).toBe(0);
-      expect(result).toContainEqual({
-        startPos: 0,
-        endPos: 5,
-        type: 'checkboxChecked'
-      });
+      expect(result).toContainEqual({ startPos: 3, endPos: 4, type: 'checkboxChecked' });
     });
   });
 
@@ -91,11 +74,8 @@ describe('MarkdownParser - Checkbox/Task List', () => {
       const result = parser.extractDecorations(markdown);
 
       expect(result.filter(d => d.type === 'listItem').length).toBe(0);
-      expect(result).toContainEqual({
-        startPos: 2,
-        endPos: 7,
-        type: 'checkboxUnchecked'
-      });
+      expect(result).toContainEqual({ startPos: 5, endPos: 6, type: 'checkboxUnchecked' });
+      expect(result).toContainEqual({ startPos: 2, endPos: 5, type: 'checkboxBracket' });
     });
   });
 

--- a/src/parser/list-quote.ts
+++ b/src/parser/list-quote.ts
@@ -84,7 +84,7 @@ export function processListItem(
     if (markerEnd < end && text[markerEnd] === ' ') {
       markerEnd++;
     }
-    if (tryAddCheckboxDecorations(text, markerStart, markerEnd, end, decorations, false)) {
+    if (tryAddCheckboxDecorations(text, markerStart, markerEnd, end, decorations, scopes, false)) {
       return;
     }
     decorations.push({ startPos: markerStart, endPos: markerEnd, type: 'listItem' });
@@ -118,7 +118,7 @@ export function processListItem(
         writtenNumber !== autoNumber;
 
       if (!autoNumberEnabled) {
-        tryAddCheckboxDecorations(text, markerStart, markerEnd, end, decorations, true);
+        tryAddCheckboxDecorations(text, markerStart, markerEnd, end, decorations, scopes, true);
         return;
       }
 
@@ -129,6 +129,7 @@ export function processListItem(
           markerEnd,
           end,
           decorations,
+          scopes,
           true,
           replacement,
           sourceMismatch,
@@ -181,6 +182,7 @@ function tryAddCheckboxDecorations(
   markerEnd: number,
   end: number,
   decorations: DecorationRange[],
+  scopes: ScopeRange[],
   isOrderedList: boolean,
   orderedReplacement?: string,
   orderedListMarkerMismatch?: boolean,
@@ -215,10 +217,23 @@ function tryAddCheckboxDecorations(
     });
   }
 
+  // The box has to sit on a single real character. VS Code's mouse hit testing
+  // skips a run of characters whose decoration collapses it, so a box drawn as
+  // a pseudo-element over "- [ ]" is not clickable at all; one drawn on the
+  // state character itself is. Everything around it is hidden separately.
+  const boxStart = checkboxStart + 1;
+  const prefixStart = isOrderedList ? checkboxStart : markerStart;
+
+  decorations.push({ startPos: prefixStart, endPos: boxStart, type: 'checkboxBracket' });
   decorations.push({
-    startPos: isOrderedList ? checkboxStart : markerStart,
-    endPos: checkboxEnd,
+    startPos: boxStart,
+    endPos: boxStart + 1,
     type: isChecked ? 'checkboxChecked' : 'checkboxUnchecked',
   });
+  decorations.push({ startPos: boxStart + 1, endPos: checkboxEnd, type: 'checkboxBracket' });
+
+  // One scope over the whole checkbox so moving the cursor onto any part of it
+  // reveals the raw `- [ ]` as a unit rather than half-rendered.
+  addScope(scopes, prefixStart, checkboxEnd, 'checkbox');
   return true;
 }

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -72,6 +72,7 @@ export type DecorationType =
   | "orderedListItem"
   | "checkboxUnchecked"
   | "checkboxChecked"
+  | "checkboxBracket"
   | "horizontalRule"
   | "frontmatter"
   | "frontmatterDelimiter"


### PR DESCRIPTION
## Problem

Clicking a rendered checkbox does nothing. The box even carries `cursor: pointer`, so it advertises a click it never handles.

## Root cause

The click never reaches `handleCheckboxClick` at all.

The box is painted into a `before` attachment over `- [ ]`, which `CheckboxUncheckedDecorationType` collapses with `textDecoration: 'none; display: none;'`. VS Code's mouse hit testing walks **real characters** and skips both collapsed runs and attachment spans, so clicking the box produces no selection change — and the toggle only ever runs from `onDidChangeTextEditorSelection`.

Measured over CDP against a real editor, clicking across the rendered box of `- [ ] task` at 1px steps from the line start:

| offset into the line | cursor after the click |
|---|---|
| 1px | Ln 3, Col 7 |
| **3–13px** (the box) | **unchanged — no event at all** |
| 15px+ | Ln 3, Col 7 |

The 14px the box occupies is a dead zone, and clicks landing just outside it resolve to column 7 — the `t` of the label — never into the brackets. `pointer-events: none` on the attachment makes no difference; VS Code's hit testing does not consult it.

## Fix

Split the decoration so the box sits on the checkbox's **state character alone** (the space or the `x`), with the list marker and both brackets hidden by a new `checkboxBracket` type on either side. A single decorated character is an ordinary hit-testing target, so the whole box becomes clickable.

Verified in a real editor at ten offsets across the box, in both directions: every one toggles.

Two consequences worth calling out:

- **Inline decorations never emit the border properties.** Only whole-line ones do — which is why `HorizontalRuleDecorationType` can use `borderWidth`/`borderStyle`. Confirmed from the generated CSS rule: neither the `border` shorthand nor the long-hand survived. The box is therefore drawn through the same `textDecoration` escape hatch this file already uses elsewhere, with `color` feeding `currentColor`.
- **The checked state shows the `x` of `[x]` inside the box rather than a tick.** A tick drawn as a `before` attachment sits over the middle of the box and makes exactly that part unclickable again — the same bug in miniature. It was measurable: with the tick in place, offsets 13 and 15 stopped toggling while the rest still worked.

The three parts share one `'checkbox'` scope, so moving the cursor onto any of them reveals the raw `- [ ]` as a unit instead of half-rendered.

## Tests

- `parser-checkbox.test.ts` updated for the split ranges, including the ordered-list and indented cases.
- `decoration-colors.test.ts` now pins the contract that actually matters: the box is styled on the element itself, with no `before`/`after` attachment — a regression there silently makes the checkbox unclickable again while everything still *looks* right.
- Existing coverage of the toggle logic is unchanged.

`npm run validate` passes.

## Note

`parser/core.ts` carries a second, unreferenced copy of `tryAddCheckboxDecorations` (0 call sites) that still has the old shape. Left alone to keep this focused, but it will drift.
