### PR TITLE
fix(decorator): keep mermaid diagrams visible while scrolling

### DIFF
--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -648,3 +648,22 @@ export function MermaidHoverIndicatorDecorationType() {
     opacity: '0.2', // Apply opacity to the entire decoration
   });
 }
+
+/**
+ * Creates a decoration type that collapses the source of a rendered mermaid block.
+ *
+ * The parser only hides the fence lines, so the diagram source itself is hidden
+ * here: zero-width and transparent, which keeps the block's line count (and with
+ * it the vertical space the diagram is drawn into) while showing nothing.
+ *
+ * Kept separate from the diagram image so the image can be re-anchored to a
+ * different line as the block scrolls without disturbing the hidden source.
+ *
+ * @returns {vscode.TextEditorDecorationType} A decoration type hiding mermaid source
+ */
+export function MermaidSourceDecorationType() {
+  return window.createTextEditorDecorationType({
+    color: 'transparent',
+    textDecoration: 'none; display: inline-block; width: 0;',
+  });
+}

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -17,7 +17,7 @@ import { handleCheckboxClick } from './decorator/checkbox-toggle';
 import { MermaidDiagramDecorations } from './decorator/mermaid-diagram-decorations';
 import { DecoratorUpdateScheduler } from './decorator/update-scheduler';
 import { MathDecorations } from './math/math-decorations';
-import { MermaidHoverIndicatorDecorationType } from './decorations';
+import { MermaidHoverIndicatorDecorationType, MermaidSourceDecorationType } from './decorations';
 import { isSupportedMarkdownLanguage } from './language-support';
 import { logDebug, logPerformanceMetric } from './logging';
 import { applyMathDecorationsForEditor } from './decorator/math-region-application';
@@ -29,6 +29,8 @@ const PERFORMANCE_CONSTANTS = {
   DEBOUNCE_TIMEOUT_MS: 150,
   IDLE_CALLBACK_TIMEOUT_MS: 300,
   MERMAID_MAX_CONCURRENCY: 4,
+  /** Scroll events fire per frame; re-anchoring only moves in whole lines. */
+  VISIBLE_RANGE_THROTTLE_MS: 50,
 } as const;
 
 
@@ -70,6 +72,8 @@ export class Decorator {
   );
   private mathDecorations = new MathDecorations();
   private mermaidHoverIndicatorDecorationType = MermaidHoverIndicatorDecorationType();
+  private mermaidSourceDecorationType = MermaidSourceDecorationType();
+  private visibleRangeThrottleTimer: ReturnType<typeof setTimeout> | undefined;
   private readonly fileDecorationState: FileDecorationStateStore;
   private readonly updateScheduler: DecoratorUpdateScheduler;
 
@@ -157,6 +161,49 @@ export class Decorator {
   }
 
   // Checkbox behavior lives in decorator/checkbox-toggle.ts
+
+  /**
+   * Re-anchors Mermaid diagrams after the viewport moved (throttled).
+   *
+   * A diagram image is a `before` attachment on one line, and VS Code only
+   * builds DOM for visible lines, so a diagram whose opening fence scrolls above
+   * the viewport would otherwise disappear. Reads from the parse cache — no
+   * reparse — and touches only the Mermaid decorations.
+   *
+   * @example
+   * decorator.updateMermaidForVisibleRanges();
+   */
+  updateMermaidForVisibleRanges() {
+    if (this.visibleRangeThrottleTimer) {
+      return;
+    }
+
+    this.visibleRangeThrottleTimer = setTimeout(() => {
+      this.visibleRangeThrottleTimer = undefined;
+      this.reanchorMermaidDiagrams();
+    }, PERFORMANCE_CONSTANTS.VISIBLE_RANGE_THROTTLE_MS);
+  }
+
+  private reanchorMermaidDiagrams() {
+    if (!this.activeEditor || !this.isMarkdownDocument()) {
+      return;
+    }
+
+    const document = this.activeEditor.document;
+    if (!this.isEnabledForUri(document.uri.toString())) {
+      return;
+    }
+    if (this.skipDecorationsInDiffView && this.isDiffEditor()) {
+      return;
+    }
+
+    const { mermaidBlocks, text } = this.parseDocument(document);
+    if (mermaidBlocks.length === 0) {
+      return;
+    }
+
+    void this.updateMermaidDiagrams(mermaidBlocks, text, document.version);
+  }
 
   /**
    * Updates decorations for document changes (debounced with batching).
@@ -270,6 +317,7 @@ export class Decorator {
     this.mermaidDecorations.clear(this.activeEditor);
     this.mathDecorations.clear(this.activeEditor);
     this.activeEditor.setDecorations(this.mermaidHoverIndicatorDecorationType, []);
+    this.activeEditor.setDecorations(this.mermaidSourceDecorationType, []);
   }
 
   /**
@@ -446,7 +494,8 @@ export class Decorator {
       mermaidBlocks,
       text,
       documentVersion,
-      this.mermaidHoverIndicatorDecorationType
+      this.mermaidHoverIndicatorDecorationType,
+      this.mermaidSourceDecorationType
     );
   }
 
@@ -654,6 +703,11 @@ export class Decorator {
     this.updateScheduler.dispose();
     this.decorationTypes.dispose();
     this.mermaidHoverIndicatorDecorationType.dispose();
+    this.mermaidSourceDecorationType.dispose();
+    if (this.visibleRangeThrottleTimer) {
+      clearTimeout(this.visibleRangeThrottleTimer);
+      this.visibleRangeThrottleTimer = undefined;
+    }
   }
 
 

--- a/src/decorator/__tests__/decorator-mermaid.test.ts
+++ b/src/decorator/__tests__/decorator-mermaid.test.ts
@@ -9,7 +9,7 @@ vi.mock('../../mermaid/mermaid-renderer', () => ({
 
 import { Decorator } from '../../decorator';
 import { MarkdownParseCache } from '../../markdown-parse-cache';
-import { TextDocument, TextEditor, Selection, Uri } from '../../test/__mocks__/vscode';
+import { TextDocument, TextEditor, Selection, Range, Position, Uri } from '../../test/__mocks__/vscode';
 import { renderMermaidSvg } from '../../mermaid/mermaid-renderer';
 
 const mockRenderMermaidSvg = vi.mocked(renderMermaidSvg);
@@ -108,5 +108,74 @@ describe('Decorator - Mermaid diagrams', () => {
 
     expect(mockRenderMermaidSvg).toHaveBeenCalledTimes(1);
     expect(applyMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The diagram image is a `before` attachment on a single line, and VS Code
+  // only builds DOM for visible lines. Anchoring at the opening fence made the
+  // whole diagram vanish as soon as the top of the block scrolled out of view.
+  describe('re-anchoring while scrolling', () => {
+    /** Renders a 20-line diagram with the given viewport, returning apply()'s arguments. */
+    async function renderWithViewport(firstVisibleLine: number, lastVisibleLine: number) {
+      const blockLines = ['```mermaid', 'graph TD', ...Array(17).fill('  A --> B'), '```'];
+      const longBlock = blockLines.join('\n');
+      const fullText = `${longBlock}\nAfter`;
+      const document = new TextDocument(Uri.file('test.md'), 'markdown', 1, fullText);
+      const outsidePosition = document.positionAt(fullText.indexOf('After') + 1);
+      const viewport = new Range(
+        new Position(firstVisibleLine, 0),
+        new Position(lastVisibleLine, 0)
+      );
+      const editor = new TextEditor(
+        document,
+        [new Selection(outsidePosition, outsidePosition)],
+        [viewport]
+      );
+      const decorator = new Decorator(new MarkdownParseCache({} as any));
+
+      (decorator as any).activeEditor = editor;
+      const applyMock = vi.fn();
+      (decorator as any).mermaidCoordinator.mermaidDecorations = {
+        apply: applyMock,
+        clear: vi.fn(),
+      };
+      const sourceRanges: any[] = [];
+      editor.setDecorations = vi.fn((type: any, ranges: any[]) => {
+        if (type === (decorator as any).mermaidSourceDecorationType) {
+          sourceRanges.push(...ranges);
+        }
+      });
+
+      const blocks = [
+        { startPos: 0, endPos: longBlock.length, source: 'graph TD\n  A --> B', numLines: 18 },
+      ];
+      await (decorator as any).updateMermaidDiagrams(blocks, fullText, document.version);
+
+      const [, rangesByKey, , lineOffsetsByKey] = applyMock.mock.calls[0];
+      const [key] = [...rangesByKey.keys()];
+      return {
+        anchorLine: rangesByKey.get(key)[0].start.line,
+        lineOffset: lineOffsetsByKey.get(key),
+        sourceRanges,
+      };
+    }
+
+    it('anchors at the block start while the whole block is visible', async () => {
+      const { anchorLine, lineOffset } = await renderWithViewport(0, 40);
+      expect(anchorLine).toBe(0);
+      expect(lineOffset).toBe(0);
+    });
+
+    it('re-anchors to the first visible line once the block top scrolls away', async () => {
+      const { anchorLine, lineOffset } = await renderWithViewport(6, 40);
+      expect(anchorLine).toBe(6);
+      expect(lineOffset).toBe(6);
+    });
+
+    it('keeps the source hidden across the whole block regardless of the anchor', async () => {
+      const { sourceRanges } = await renderWithViewport(6, 40);
+      expect(sourceRanges).toHaveLength(1);
+      expect(sourceRanges[0].start.line).toBe(0);
+      expect(sourceRanges[0].end.line).toBe(19);
+    });
   });
 });

--- a/src/decorator/__tests__/mermaid-anchor.test.ts
+++ b/src/decorator/__tests__/mermaid-anchor.test.ts
@@ -1,0 +1,87 @@
+import { computeMermaidAnchor } from '../mermaid-anchor';
+
+/** Build the visible-range shape the anchor helper consumes. */
+function visible(startLine: number, endLine: number) {
+  return [{ start: { line: startLine }, end: { line: endLine } }];
+}
+
+describe('computeMermaidAnchor', () => {
+  // A diagram spanning lines 10-30 in a viewport showing lines 5-40.
+  describe('block fully inside the viewport', () => {
+    it('anchors at the block start with no offset', () => {
+      expect(computeMermaidAnchor(10, 30, visible(5, 40))).toEqual({
+        anchorLine: 10,
+        lineOffset: 0,
+      });
+    });
+
+    it('anchors at the block start when the block starts exactly at the top', () => {
+      expect(computeMermaidAnchor(10, 30, visible(10, 40))).toEqual({
+        anchorLine: 10,
+        lineOffset: 0,
+      });
+    });
+  });
+
+  // The bug: once the opening fence scrolls above the viewport, VS Code recycles
+  // that line's DOM and the `before` pseudo-element carrying the SVG disappears.
+  describe('block top scrolled above the viewport', () => {
+    it('re-anchors to the first visible line and reports the offset', () => {
+      expect(computeMermaidAnchor(10, 30, visible(13, 40))).toEqual({
+        anchorLine: 13,
+        lineOffset: 3,
+      });
+    });
+
+    it('re-anchors when only the last line of the block is still visible', () => {
+      expect(computeMermaidAnchor(10, 30, visible(30, 50))).toEqual({
+        anchorLine: 30,
+        lineOffset: 20,
+      });
+    });
+  });
+
+  describe('block outside the viewport', () => {
+    it('keeps the plain anchor when the block is entirely below the viewport', () => {
+      expect(computeMermaidAnchor(10, 30, visible(0, 5))).toEqual({
+        anchorLine: 10,
+        lineOffset: 0,
+      });
+    });
+
+    it('keeps the plain anchor when the block is entirely above the viewport', () => {
+      // Reusing offset 0 here avoids creating a decoration type nobody can see.
+      expect(computeMermaidAnchor(10, 30, visible(50, 80))).toEqual({
+        anchorLine: 10,
+        lineOffset: 0,
+      });
+    });
+  });
+
+  describe('degenerate input', () => {
+    it('keeps the plain anchor when no visible ranges are reported', () => {
+      expect(computeMermaidAnchor(10, 30, [])).toEqual({
+        anchorLine: 10,
+        lineOffset: 0,
+      });
+    });
+
+    it('uses the first range start across folded, discontiguous ranges', () => {
+      const folded = [
+        { start: { line: 12 }, end: { line: 14 } },
+        { start: { line: 20 }, end: { line: 40 } },
+      ];
+      expect(computeMermaidAnchor(10, 30, folded)).toEqual({
+        anchorLine: 12,
+        lineOffset: 2,
+      });
+    });
+
+    it('handles a single-line block', () => {
+      expect(computeMermaidAnchor(10, 10, visible(10, 40))).toEqual({
+        anchorLine: 10,
+        lineOffset: 0,
+      });
+    });
+  });
+});

--- a/src/decorator/mermaid-anchor.ts
+++ b/src/decorator/mermaid-anchor.ts
@@ -1,0 +1,51 @@
+/** Minimal shape of `TextEditor.visibleRanges`, kept structural so it is trivially testable. */
+export type VisibleLineRange = {
+  start: { line: number };
+  end: { line: number };
+};
+
+export type MermaidAnchor = {
+  /** Line the diagram decoration attaches to. */
+  anchorLine: number;
+  /** Lines the anchor was pushed down from the block start, compensated with a negative margin. */
+  lineOffset: number;
+};
+
+/**
+ * Picks the line a Mermaid diagram should hang off for the current viewport.
+ *
+ * The rendered SVG lives in a `before` pseudo-element on a single line. VS Code
+ * virtualises the editor and only builds DOM for visible lines, so anchoring at
+ * the opening fence makes the whole diagram vanish as soon as the top of the
+ * block scrolls past the viewport. Re-anchoring to the first still-visible line
+ * of the block keeps the element alive; the caller offsets it back up by
+ * `lineOffset` line heights so the diagram does not appear to jump.
+ *
+ * @param blockStartLine - First line of the Mermaid block
+ * @param blockEndLine - Last line of the Mermaid block
+ * @param visibleRanges - Editor viewport ranges (may be discontiguous when folded)
+ * @returns The line to anchor on and how far it was pushed down
+ */
+export function computeMermaidAnchor(
+  blockStartLine: number,
+  blockEndLine: number,
+  visibleRanges: readonly VisibleLineRange[]
+): MermaidAnchor {
+  const plainAnchor: MermaidAnchor = { anchorLine: blockStartLine, lineOffset: 0 };
+
+  if (visibleRanges.length === 0) {
+    return plainAnchor;
+  }
+
+  const firstVisibleLine = visibleRanges[0].start.line;
+  const lastVisibleLine = visibleRanges[visibleRanges.length - 1].end.line;
+
+  // Nothing to compensate for when the block cannot be seen at all; reusing the
+  // plain anchor also avoids allocating a decoration type per offscreen offset.
+  if (blockEndLine < firstVisibleLine || blockStartLine > lastVisibleLine) {
+    return plainAnchor;
+  }
+
+  const anchorLine = Math.min(Math.max(firstVisibleLine, blockStartLine), blockEndLine);
+  return { anchorLine, lineOffset: anchorLine - blockStartLine };
+}

--- a/src/decorator/mermaid-diagram-decorations.ts
+++ b/src/decorator/mermaid-diagram-decorations.ts
@@ -73,9 +73,12 @@ export class MermaidDiagramDecorations {
     // Re-anchored diagrams hang off a lower line, so shift them back up by the
     // rows they skipped. The overflow is clipped by the viewport, which is
     // exactly the part that scrolled away.
-    const margin = lineOffset > 0
-      ? `-${lineOffset * getEditorLineHeight()}px 0 0 0`
-      : undefined;
+    // The attachment renders as an inline pseudo-element, and vertical margins
+    // do not apply to inline boxes, so it has to become inline-block for the
+    // shift to take effect at all.
+    const shiftUp = lineOffset > 0
+      ? `margin-top: -${lineOffset * getEditorLineHeight()}px;`
+      : '';
 
     // Mermaid themes handle colors internally, so we don't need to invert.
     // Only the image lives here; the block's source is collapsed separately by
@@ -83,8 +86,7 @@ export class MermaidDiagramDecorations {
     const decorationType = window.createTextEditorDecorationType({
       before: {
         contentIconPath: Uri.parse(dataUri),
-        textDecoration: 'none;',
-        margin,
+        textDecoration: `none; display: inline-block; vertical-align: top; ${shiftUp}`,
       },
     });
 

--- a/src/decorator/mermaid-diagram-decorations.ts
+++ b/src/decorator/mermaid-diagram-decorations.ts
@@ -1,4 +1,5 @@
 import { type TextEditor, window, Uri, type TextEditorDecorationType, type Range, ColorThemeKind } from 'vscode';
+import { getEditorLineHeight } from '../editor-metrics';
 
 type MermaidDecorationEntry = {
   decorationType: TextEditorDecorationType;
@@ -12,7 +13,19 @@ export class MermaidDiagramDecorations {
 
   constructor(private maxEntries: number = 50) {}
 
-  apply(editor: TextEditor, rangesByKey: Map<string, Range[]>, dataUrisByKey: Map<string, string>): void {
+  /**
+   * Applies diagram decorations, one decoration type per rendered SVG.
+   *
+   * @param lineOffsetsByKey - Lines each diagram was re-anchored down by, pulled
+   *   back up with a negative margin so the diagram keeps its place while the
+   *   top of its block is scrolled out of view. Absent means no offset.
+   */
+  apply(
+    editor: TextEditor,
+    rangesByKey: Map<string, Range[]>,
+    dataUrisByKey: Map<string, string>,
+    lineOffsetsByKey?: Map<string, number>
+  ): void {
     const usedKeys = new Set<string>();
     const isDarkTheme = window.activeColorTheme.kind === ColorThemeKind.Dark ||
       window.activeColorTheme.kind === ColorThemeKind.HighContrast;
@@ -22,7 +35,7 @@ export class MermaidDiagramDecorations {
       if (!dataUri || ranges.length === 0) {
         continue;
       }
-      const entry = this.getOrCreateEntry(key, dataUri, isDarkTheme);
+      const entry = this.getOrCreateEntry(key, dataUri, isDarkTheme, lineOffsetsByKey?.get(key) ?? 0);
       usedKeys.add(key);
       editor.setDecorations(entry.decorationType, ranges);
     }
@@ -38,7 +51,12 @@ export class MermaidDiagramDecorations {
     this.cache.clear();
   }
 
-  private getOrCreateEntry(key: string, dataUri: string, isDarkTheme: boolean): MermaidDecorationEntry {
+  private getOrCreateEntry(
+    key: string,
+    dataUri: string,
+    isDarkTheme: boolean,
+    lineOffset: number
+  ): MermaidDecorationEntry {
     const existing = this.cache.get(key);
     // Invalidate cache if theme changed
     if (existing && existing.isDarkTheme === isDarkTheme) {
@@ -52,14 +70,21 @@ export class MermaidDiagramDecorations {
       this.cache.delete(key);
     }
 
-    // Mermaid themes handle colors internally, so we don't need to invert
-    // Match Markless pattern exactly: transparent text, SVG in before pseudo-element
+    // Re-anchored diagrams hang off a lower line, so shift them back up by the
+    // rows they skipped. The overflow is clipped by the viewport, which is
+    // exactly the part that scrolled away.
+    const margin = lineOffset > 0
+      ? `-${lineOffset * getEditorLineHeight()}px 0 0 0`
+      : undefined;
+
+    // Mermaid themes handle colors internally, so we don't need to invert.
+    // Only the image lives here; the block's source is collapsed separately by
+    // MermaidSourceDecorationType.
     const decorationType = window.createTextEditorDecorationType({
-      color: 'transparent',
-      textDecoration: 'none; display: inline-block; width: 0;',
       before: {
         contentIconPath: Uri.parse(dataUri),
         textDecoration: 'none;',
+        margin,
       },
     });
 

--- a/src/decorator/mermaid-update-coordinator.ts
+++ b/src/decorator/mermaid-update-coordinator.ts
@@ -4,6 +4,7 @@ import type { MermaidBlock } from '../parser';
 import { mapNormalizedToOriginal } from '../position-mapping';
 import { renderMermaidSvg, svgToDataUri, createErrorSvg } from '../mermaid/mermaid-renderer';
 import { MermaidDiagramDecorations } from './mermaid-diagram-decorations';
+import { computeMermaidAnchor } from './mermaid-anchor';
 import { createRange, isSelectionOrCursorInsideOffsets } from './editor-decoration-applier';
 import { logWarn } from '../logging';
 
@@ -74,10 +75,12 @@ export class MermaidUpdateCoordinator {
     normalizedText: string,
     documentVersion: number,
     hoverIndicatorDecorationType: { dispose(): void } & { key?: string },
+    sourceDecorationType: { dispose(): void } & { key?: string },
   ): Promise<void> {
     if (mermaidBlocks.length === 0) {
       this.mermaidDecorations.clear(editor);
       editor.setDecorations(hoverIndicatorDecorationType as never, []);
+      editor.setDecorations(sourceDecorationType as never, []);
       return;
     }
 
@@ -90,14 +93,23 @@ export class MermaidUpdateCoordinator {
 
     const rangesByKey = new Map<string, Range[]>();
     const dataUrisByKey = new Map<string, string>();
+    const lineOffsetsByKey = new Map<string, number>();
     const indicatorRanges: Range[] = [];
+    const sourceRanges: Range[] = [];
     const originalText = editor.document.getText();
     const dataUriPromisesByKey = new Map<string, Promise<string>>();
 
     const results = await mapWithConcurrency(
       mermaidBlocks,
       this.maxConcurrency,
-      async (block): Promise<{ key: string; range: Range; dataUri: string; indicatorRange: Range } | null> => {
+      async (block): Promise<{
+        key: string;
+        range: Range;
+        dataUri: string;
+        indicatorRange: Range;
+        sourceRange: Range;
+        lineOffset: number;
+      } | null> => {
         if (token !== this.mermaidUpdateToken || editor.document.version !== documentVersion) {
           return null;
         }
@@ -106,10 +118,21 @@ export class MermaidUpdateCoordinator {
           return null;
         }
 
-        const range = createRange(editor, block.startPos, block.endPos, normalizedText);
-        if (!range) {
+        const sourceRange = createRange(editor, block.startPos, block.endPos, normalizedText);
+        if (!sourceRange) {
           return null;
         }
+
+        // The image hangs off a single line, and VS Code only builds DOM for
+        // visible lines — anchoring at the block start makes the diagram vanish
+        // once the opening fence scrolls above the viewport.
+        const anchor = computeMermaidAnchor(
+          sourceRange.start.line,
+          sourceRange.end.line,
+          editor.visibleRanges ?? []
+        );
+        const anchorPosition = new Position(anchor.anchorLine, 0);
+        const range = new Range(anchorPosition, anchorPosition);
 
         const blockStart = mapNormalizedToOriginal(block.startPos, normalizedText);
         const openingFenceLineEnd = originalText.indexOf('\n', blockStart);
@@ -122,8 +145,12 @@ export class MermaidUpdateCoordinator {
           new Position(contentStartPos.line, indicatorEndChar)
         );
 
-        const key = getMermaidBlockCacheKey(block, theme, fontFamily);
-        let dataUriPromise = dataUriPromisesByKey.get(key);
+        // The rendered SVG does not depend on the anchor, so it is deduplicated
+        // by svgKey; the decoration type does, because the offset rides on its
+        // margin, so its key carries the offset too.
+        const svgKey = getMermaidBlockCacheKey(block, theme, fontFamily);
+        const key = `${svgKey}:${anchor.lineOffset}`;
+        let dataUriPromise = dataUriPromisesByKey.get(svgKey);
         if (!dataUriPromise) {
           dataUriPromise = (async () => {
             try {
@@ -143,7 +170,7 @@ export class MermaidUpdateCoordinator {
               return svgToDataUri(errorSvg);
             }
           })();
-          dataUriPromisesByKey.set(key, dataUriPromise);
+          dataUriPromisesByKey.set(svgKey, dataUriPromise);
         }
 
         const dataUri = await dataUriPromise;
@@ -151,7 +178,7 @@ export class MermaidUpdateCoordinator {
           return null;
         }
 
-        return { key, range, dataUri, indicatorRange };
+        return { key, range, dataUri, indicatorRange, sourceRange, lineOffset: anchor.lineOffset };
       }
     );
 
@@ -160,17 +187,20 @@ export class MermaidUpdateCoordinator {
         continue;
       }
       dataUrisByKey.set(result.key, result.dataUri);
+      lineOffsetsByKey.set(result.key, result.lineOffset);
       const ranges = rangesByKey.get(result.key) || [];
       ranges.push(result.range);
       rangesByKey.set(result.key, ranges);
       indicatorRanges.push(result.indicatorRange);
+      sourceRanges.push(result.sourceRange);
     }
 
     if (token !== this.mermaidUpdateToken || editor.document.version !== documentVersion) {
       return;
     }
 
-    this.mermaidDecorations.apply(editor, rangesByKey, dataUrisByKey);
+    this.mermaidDecorations.apply(editor, rangesByKey, dataUrisByKey, lineOffsetsByKey);
     editor.setDecorations(hoverIndicatorDecorationType as never, indicatorRanges);
+    editor.setDecorations(sourceDecorationType as never, sourceRanges);
   }
 }

--- a/src/editor-metrics.ts
+++ b/src/editor-metrics.ts
@@ -1,0 +1,28 @@
+import { workspace } from 'vscode';
+
+/**
+ * Editor line height in pixels, derived from the `editor.fontSize` and
+ * `editor.lineHeight` settings.
+ *
+ * VS Code exposes no API for the rendered line height, so this mirrors its
+ * fallback rules (as Markless does): `lineHeight` of 0 or below 8 means "auto"
+ * and scales off the font size, values below 10 are treated as a multiplier,
+ * and anything larger is an explicit pixel height.
+ *
+ * @returns Line height in pixels, never below 8
+ */
+export function getEditorLineHeight(): number {
+  const editorConfig = workspace.getConfiguration('editor');
+  const fontSize = editorConfig.get<number>('fontSize', 14);
+  const lineHeightSetting = editorConfig.get<number>('lineHeight', 0);
+
+  if (lineHeightSetting >= 10) {
+    return Math.round(lineHeightSetting);
+  }
+  if (lineHeightSetting >= 8) {
+    return Math.round(fontSize * lineHeightSetting);
+  }
+
+  const multiplier = process.platform === 'darwin' ? 1.5 : 1.35;
+  return Math.max(8, Math.round(fontSize * multiplier));
+}

--- a/src/math/math-decorations.ts
+++ b/src/math/math-decorations.ts
@@ -1,5 +1,6 @@
 import { type TextEditor, window, Uri, type Range, ColorThemeKind, workspace } from 'vscode';
 import type { MathRegion } from '../parser';
+import { getEditorLineHeight } from '../editor-metrics';
 import { renderMathToDataUri } from './math-renderer';
 
 /** Default editor foreground colors by theme (VS Code defaults). */
@@ -10,21 +11,8 @@ const DEFAULT_FOREGROUND = {
 
 /** Compute line height from editor settings, aligned with mermaid sizing fallback. */
 function getEditorHeights(): { blockHeight: number; inlineHeight: number; lineHeight: number } {
-  const editorConfig = workspace.getConfiguration('editor');
-  const fontSize = editorConfig.get<number>('fontSize', 14);
-  const lineHeightSetting = editorConfig.get<number>('lineHeight', 0);
-  let lineHeight: number;
-  if (lineHeightSetting === 0 || lineHeightSetting < 8) {
-    const multiplier = process.platform === 'darwin' ? 1.5 : 1.35;
-    lineHeight = Math.round(fontSize * multiplier);
-    if (lineHeight < 8) {
-      lineHeight = 8;
-    }
-  } else if (lineHeightSetting >= 10) {
-    lineHeight = Math.round(lineHeightSetting);
-  } else {
-    lineHeight = Math.round(fontSize * lineHeightSetting);
-  }
+  const fontSize = workspace.getConfiguration('editor').get<number>('fontSize', 14);
+  const lineHeight = getEditorLineHeight();
   const inlineHeight = Math.round(fontSize * 1.2);
   return { blockHeight: lineHeight, inlineHeight, lineHeight };
 }

--- a/src/registration/__tests__/register-event-handlers.test.ts
+++ b/src/registration/__tests__/register-event-handlers.test.ts
@@ -19,6 +19,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      updateMermaidForVisibleRanges: vi.fn(),
     };
     const linkClickHandler = {
       setEnabled: vi.fn(),
@@ -26,13 +27,16 @@ describe('registerEventHandlers', () => {
 
     const disposables = registerEventHandlers(decorator as any, linkClickHandler as any);
 
-    expect(disposables).toHaveLength(6);
+    expect(disposables).toHaveLength(7);
   });
 
   it('routes editor and workspace events to the decorator', () => {
     let activeEditorListener: ((editor: vscode.TextEditor | undefined) => void) | undefined;
     let selectionListener:
       | ((event: { kind: vscode.TextEditorSelectionChangeKind }) => void)
+      | undefined;
+    let visibleRangesListener:
+      | ((event: { textEditor: vscode.TextEditor }) => void)
       | undefined;
     let documentChangeListener:
       | ((event: { document: vscode.TextDocument }) => void)
@@ -47,6 +51,10 @@ describe('registerEventHandlers', () => {
     }) as any;
     vscode.window.onDidChangeTextEditorSelection = vi.fn((listener) => {
       selectionListener = listener;
+      return { dispose: vi.fn() };
+    }) as any;
+    vscode.window.onDidChangeTextEditorVisibleRanges = vi.fn((listener) => {
+      visibleRangesListener = listener;
       return { dispose: vi.fn() };
     }) as any;
     vscode.workspace.onDidChangeTextDocument = vi.fn((listener) => {
@@ -78,6 +86,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      updateMermaidForVisibleRanges: vi.fn(),
     };
 
     registerEventHandlers(decorator as any, { setEnabled: vi.fn() } as any);
@@ -95,6 +104,14 @@ describe('registerEventHandlers', () => {
     );
     expect(decorator.updateDecorationsFromChange).toHaveBeenCalledWith({ document });
     expect(decorator.renameFile).toHaveBeenCalledWith('file:///old.md', 'file:///new.md');
+
+    // Scrolling re-anchors mermaid diagrams, but only for the editor in front.
+    visibleRangesListener?.({ textEditor: editor });
+    expect(decorator.updateMermaidForVisibleRanges).toHaveBeenCalledTimes(1);
+
+    const backgroundEditor = new (vscode.TextEditor as any)(document, []);
+    visibleRangesListener?.({ textEditor: backgroundEditor });
+    expect(decorator.updateMermaidForVisibleRanges).toHaveBeenCalledTimes(1);
   });
 
   it('applies configuration and theme changes', () => {
@@ -126,6 +143,7 @@ describe('registerEventHandlers', () => {
       recreateCodeBlockLanguageDecorationType: vi.fn(),
       recreateColorDependentTypes: vi.fn(),
       clearMathDecorationCache: vi.fn(),
+      updateMermaidForVisibleRanges: vi.fn(),
     };
     const linkClickHandler = {
       setEnabled: vi.fn(),

--- a/src/registration/register-event-handlers.ts
+++ b/src/registration/register-event-handlers.ts
@@ -14,6 +14,11 @@ export function registerEventHandlers(
     vscode.window.onDidChangeTextEditorSelection((event) => {
       decorator.updateDecorationsForSelection(event.kind);
     }),
+    vscode.window.onDidChangeTextEditorVisibleRanges((event) => {
+      if (event.textEditor === vscode.window.activeTextEditor) {
+        decorator.updateMermaidForVisibleRanges();
+      }
+    }),
     vscode.workspace.onDidChangeTextDocument((event) => {
       if (event.document === vscode.window.activeTextEditor?.document) {
         decorator.updateDecorationsFromChange(event);

--- a/src/test/__mocks__/vscode.ts
+++ b/src/test/__mocks__/vscode.ts
@@ -180,6 +180,7 @@ class MockTextEditor {
   constructor(
     public document: MockTextDocument,
     public selections: MockSelection[],
+    public visibleRanges: MockRange[] = [],
   ) {
     this.selection = selections[0] ?? new MockSelection({ line: 0, character: 0 }, { line: 0, character: 0 });
   }
@@ -233,6 +234,7 @@ export const window = {
   showTextDocument: vi.fn(async (document: MockTextDocument) => new MockTextEditor(document, [])),
   onDidChangeActiveTextEditor: () => ({ dispose: () => {} }),
   onDidChangeTextEditorSelection: () => ({ dispose: () => {} }),
+  onDidChangeTextEditorVisibleRanges: () => ({ dispose: () => {} }),
   onDidChangeActiveColorTheme: () => ({ dispose: () => {} }),
 };
 


### PR DESCRIPTION
## Problem

Scrolling down through a tall Mermaid diagram makes the **entire diagram disappear** the moment its opening fence passes the top of the viewport, leaving a column of empty highlighted rows where it was.

## Root cause

Two separate defects, both confirmed over CDP against a real editor.

**1. The diagram is anchored to a line that gets recycled.** The rendered SVG is a single `before` attachment on the first line of the block:

```ts
// src/decorator/mermaid-diagram-decorations.ts
before: { contentIconPath: Uri.parse(dataUri) }   // the whole diagram lives here
```

VS Code virtualises the editor and only builds DOM for visible lines. Once the anchor line scrolls above the viewport its DOM is recycled, taking the pseudo-element — and the whole diagram — with it. The code block background survives because it is a whole-line decoration applied per line. `grep -rn visibleRanges src/` had no hits: nothing re-anchored the diagram as the viewport moved.

**2. Vertical margins do not apply to inline boxes.** Re-anchoring alone is not enough — the diagram has to be shifted back up by the rows it skipped, and the obvious `before.margin` silently does nothing: the attachment renders as `display: inline`, and CSS ignores vertical margins on inline boxes. The diagram then draws *downward* from its new anchor, spilling past the end of its block and covering the text below as the viewport moves.

## Fix

Re-anchor the image to the first still-visible line of the block and pull it back up by that many line heights, with the attachment made `inline-block` so the shift actually takes effect. The overflow clipped by the viewport is exactly the part that scrolled away.

Verified in a real editor at a 6-line offset: the attachment reports `display: inline-block` with `margin-top: -114px` (6 × the 19px line height), and the diagram stays inside its block with the text after it untouched.

- `decorator/mermaid-anchor.ts` — new pure function computing the anchor line and offset from `editor.visibleRanges`; a fully offscreen block keeps the plain anchor so no decoration type is allocated for an offset nobody can see.
- The offset is part of the decoration type key; the rendered SVG is deduplicated separately by a key without it, since the image does not depend on the anchor.
- Because the image now sits on a single line, collapsing the block's source moves into its own decoration type (`MermaidSourceDecorationType`) applied across the whole block. The parser only hides the fence lines (`parser/code-blocks.ts`), not the source between them, so that job had to keep covering the full range.
- Viewport changes arrive through `onDidChangeTextEditorVisibleRanges`, throttled to 50ms — re-anchoring only moves in whole lines — and served from the parse cache, so scrolling never triggers a reparse.
- Line height computation is shared in `editor-metrics.ts`, replacing the duplicate in `math-decorations.ts` (same rules, no behaviour change).

## Tests

- `mermaid-anchor.test.ts` — 9 cases: block fully visible, top scrolled away, only the last line visible, block entirely above/below the viewport, folded discontiguous ranges, no visible ranges, single-line block.
- `decorator-mermaid.test.ts` — 3 integration cases asserting the anchor line and offset actually handed to `apply()`, plus that the source stays hidden across the whole block regardless of the anchor.
- `register-event-handlers.test.ts` — the new listener fires only for the active editor.

`npm run validate` passes.
