### PR TITLE
fix(links): decode percent-encoded paths and match Unicode heading anchors

### DIFF
--- a/src/commands/__tests__/navigate-to-anchor.test.ts
+++ b/src/commands/__tests__/navigate-to-anchor.test.ts
@@ -50,4 +50,56 @@ describe('navigate-to-anchor command', () => {
 
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Anchor "missing" not found');
   });
+
+  it('matches headings in CRLF documents', async () => {
+    let handler: ((anchor: string | unknown[], documentUri?: string) => Promise<void>) | undefined;
+    (vscode.commands.registerCommand as Mock).mockImplementation((_id, cb) => {
+      handler = cb;
+      return { dispose: vi.fn() };
+    });
+
+    const document = new (vscode.TextDocument as any)(
+      vscode.Uri.file('/test.md'),
+      'markdown',
+      1,
+      '# Title\r\n## My Heading\r\n'
+    );
+    const editor = new (vscode.TextEditor as any)(document, []);
+    editor.revealRange = vi.fn();
+    (vscode.workspace.openTextDocument as Mock).mockResolvedValue(document);
+    (vscode.window.showTextDocument as Mock).mockResolvedValue(editor);
+    (vscode.window.showInformationMessage as Mock).mockClear();
+
+    createNavigateToAnchorCommand();
+    await handler?.('my-heading', 'file:///test.md');
+
+    expect(editor.revealRange).toHaveBeenCalled();
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+  });
+
+  it('matches CJK heading slugs such as #skills-目录', async () => {
+    let handler: ((anchor: string | unknown[], documentUri?: string) => Promise<void>) | undefined;
+    (vscode.commands.registerCommand as Mock).mockImplementation((_id, cb) => {
+      handler = cb;
+      return { dispose: vi.fn() };
+    });
+
+    const document = new (vscode.TextDocument as any)(
+      vscode.Uri.file('/test.md'),
+      'markdown',
+      1,
+      '# Title\r\n## Skills 目录\r\n'
+    );
+    const editor = new (vscode.TextEditor as any)(document, []);
+    editor.revealRange = vi.fn();
+    (vscode.workspace.openTextDocument as Mock).mockResolvedValue(document);
+    (vscode.window.showTextDocument as Mock).mockResolvedValue(editor);
+    (vscode.window.showInformationMessage as Mock).mockClear();
+
+    createNavigateToAnchorCommand();
+    await handler?.('skills-目录', 'file:///test.md');
+
+    expect(editor.revealRange).toHaveBeenCalled();
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/navigate-to-anchor.ts
+++ b/src/commands/navigate-to-anchor.ts
@@ -1,20 +1,45 @@
 import * as vscode from 'vscode';
 import { normalizeAnchorText } from '../position-mapping';
 
-async function navigateToAnchor(anchor: string, documentUri: string): Promise<void> {
+/**
+ * Jumps the editor to the heading that matches a markdown fragment.
+ *
+ * @param anchor - Slug, heading text, or a command-URI args array
+ * @param documentUri - File URI string; omitted when `anchor` is the args array
+ */
+async function navigateToAnchor(
+  anchor: string | unknown[],
+  documentUri?: string
+): Promise<void> {
+  // DocumentLink command URIs may pass the JSON array as a single argument
+  if (Array.isArray(anchor)) {
+    const [parsedAnchor, parsedUri] = anchor;
+    anchor = String(parsedAnchor ?? '');
+    documentUri = typeof parsedUri === 'string' ? parsedUri : documentUri;
+  }
+
+  if (typeof documentUri !== 'string' || documentUri.length === 0) {
+    void vscode.window.showInformationMessage(`Anchor "${String(anchor)}" not found`);
+    return;
+  }
+
   const uri = vscode.Uri.parse(documentUri);
   const document = await vscode.workspace.openTextDocument(uri);
   const editor = await vscode.window.showTextDocument(document);
   const text = document.getText();
-  const lines = text.split('\n');
+  // Split CRLF/CR/LF so Windows files still expose heading text (`.` cannot match `\r`)
+  const lines = text.split(/\r\n|\n|\r/);
+  const wanted = normalizeAnchorText(String(anchor ?? ''));
 
   for (let i = 0; i < lines.length; i++) {
-    const headingMatch = lines[i].match(/^#+\s+(.+)$/);
+    // Optional indent, ATX markers, optional closing hashes, stray CR
+    const headingMatch = lines[i].match(/^ {0,3}#{1,6}\s+(.+?)(?:\s+#+\s*)?\s*$/);
     if (!headingMatch) {
       continue;
     }
 
-    if (normalizeAnchorText(headingMatch[1]) !== anchor) {
+    const headingText = headingMatch[1].trim();
+    if (normalizeAnchorText(headingText) !== wanted && headingText.toLowerCase() !== wanted) {
       continue;
     }
 

--- a/src/link-targets.ts
+++ b/src/link-targets.ts
@@ -4,6 +4,56 @@ export type LinkTarget =
   | { kind: "command"; command: string; args: unknown[] }
   | { kind: "uri"; uri: vscode.Uri };
 
+/**
+ * Percent-decode a markdown href path so `link%20test.md` maps to `link test.md`.
+ *
+ * @param path - Raw href path, possibly percent-encoded
+ * @returns Decoded path, or the original string if decoding fails
+ */
+function decodeMarkdownHrefPath(path: string): string {
+  // joinPath would otherwise look for a filename that literally contains "%20"
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * Split `file.md#heading` so the fragment is not treated as part of the filename.
+ *
+ * @param href - Relative or absolute markdown href
+ * @returns Path and fragment (empty string when no hash is present)
+ */
+function splitMarkdownHref(href: string): { path: string; fragment: string } {
+  const hashIndex = href.indexOf("#");
+  if (hashIndex === -1) {
+    return { path: href, fragment: "" };
+  }
+  return { path: href.slice(0, hashIndex), fragment: href.slice(hashIndex + 1) };
+}
+
+/**
+ * Resolve a local markdown/image path after decoding percent-encoding.
+ *
+ * @param hrefPath - Path without fragment
+ * @param documentUri - URI of the document that contains the href
+ * @returns File URI, or undefined when the path is empty
+ */
+function resolveLocalMarkdownUri(
+  hrefPath: string,
+  documentUri: vscode.Uri,
+): vscode.Uri | undefined {
+  const decoded = decodeMarkdownHrefPath(hrefPath);
+  if (!decoded) {
+    return;
+  }
+  if (decoded.startsWith("/")) {
+    return vscode.Uri.file(decoded);
+  }
+  return vscode.Uri.joinPath(documentUri, "..", decoded);
+}
+
 export function resolveImageTarget(
   url: string,
   documentUri: vscode.Uri,
@@ -11,10 +61,6 @@ export function resolveImageTarget(
   const trimmed = url.trim();
   if (!trimmed) {
     return;
-  }
-
-  if (trimmed.startsWith("/")) {
-    return vscode.Uri.file(trimmed);
   }
 
   if (
@@ -30,7 +76,7 @@ export function resolveImageTarget(
     }
   }
 
-  return vscode.Uri.joinPath(documentUri, "..", trimmed);
+  return resolveLocalMarkdownUri(trimmed, documentUri);
 }
 
 export function resolveLinkTarget(
@@ -67,11 +113,22 @@ export function resolveLinkTarget(
     }
   }
 
-  if (trimmed.startsWith("/")) {
-    return { kind: "uri", uri: vscode.Uri.file(trimmed) };
+  const { path, fragment } = splitMarkdownHref(trimmed);
+  const uri = resolveLocalMarkdownUri(path, documentUri);
+  if (!uri) {
+    return;
   }
 
-  return { kind: "uri", uri: vscode.Uri.joinPath(documentUri, "..", trimmed) };
+  // Relative file plus fragment: open that file then jump to the heading
+  if (fragment) {
+    return {
+      kind: "command",
+      command: "markdown-inline-editor.navigateToAnchor",
+      args: [fragment, uri.toString()],
+    };
+  }
+
+  return { kind: "uri", uri };
 }
 
 export function toCommandUri(command: string, args: unknown[]): vscode.Uri {

--- a/src/link-targets/__tests__/link-targets.test.ts
+++ b/src/link-targets/__tests__/link-targets.test.ts
@@ -24,6 +24,11 @@ describe("link-targets", () => {
       expect(result?.toString()).toContain("image.png");
     });
 
+    it("decodes percent-encoded spaces in relative image paths", () => {
+      const result = resolveImageTarget("link%20test.png", documentUri as any);
+      expect(result?.toString()).toContain("link test.png");
+    });
+
     it("resolves external URLs", () => {
       const result = resolveImageTarget(
         "https://example.com/image.png",
@@ -60,6 +65,22 @@ describe("link-targets", () => {
       const result = resolveLinkTarget("relative.md", documentUri as any);
       expect(result?.kind).toBe("uri");
       expect(result?.uri.toString()).toContain("relative.md");
+    });
+
+    it("decodes percent-encoded spaces in relative file links", () => {
+      const result = resolveLinkTarget("link%20test.md", documentUri as any);
+      expect(result?.kind).toBe("uri");
+      expect(result?.uri.toString()).toContain("link test.md");
+      expect(result?.uri.toString()).not.toContain("link%20test.md");
+    });
+
+    it("opens a relative file then jumps to its fragment", () => {
+      const result = resolveLinkTarget("other.md#skills-目录", documentUri as any);
+      expect(result?.kind).toBe("command");
+      if (result?.kind === "command") {
+        expect(result.args[0]).toBe("skills-目录");
+        expect(String(result.args[1])).toContain("other.md");
+      }
     });
   });
 

--- a/src/position-mapping.ts
+++ b/src/position-mapping.ts
@@ -79,30 +79,40 @@ export function mapNormalizedToOriginal(normalizedPos: number, originalText?: st
 
 /**
  * Normalizes heading text to anchor format.
- * 
+ *
  * Converts heading text to the format used in markdown anchor links:
+ * - Percent-decodes fragments such as `%E7%9B%AE%E5%BD%95`
  * - Converts to lowercase
- * - Removes non-word characters (except spaces and hyphens)
+ * - Removes punctuation while keeping Unicode letters, numbers, underscores, spaces, and hyphens
  * - Replaces spaces with hyphens
- * - Collapses multiple hyphens into single hyphen
+ * - Collapses multiple hyphens into a single hyphen
  * - Trims leading/trailing whitespace
- * 
- * This matches the GitHub Flavored Markdown (GFM) anchor link generation algorithm.
- * 
- * @param text - The heading text to normalize
+ *
+ * This approximates GitHub Flavored Markdown (GFM) slug generation, including CJK headings.
+ *
+ * @param text - The heading text or link fragment to normalize
  * @returns Normalized anchor text
- * 
+ *
  * @example
  * ```typescript
  * normalizeAnchorText('Hello World!') // Returns 'hello-world'
- * normalizeAnchorText('  Test  123  ') // Returns 'test-123'
+ * normalizeAnchorText('Skills 目录') // Returns 'skills-目录'
  * normalizeAnchorText('Multiple---Hyphens') // Returns 'multiple-hyphens'
  * ```
  */
 export function normalizeAnchorText(text: string): string {
-  return text
+  // Percent-decode first so encoded CJK fragments still match heading slugs
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(text);
+  } catch {
+    decoded = text;
+  }
+
+  // Keep Unicode letters/digits/underscore (JS \w is ASCII-only and would strip CJK)
+  return decoded
     .toLowerCase()
-    .replace(/[^\w\s-]/g, '')
+    .replace(/[^\p{L}\p{N}_\s-]+/gu, '')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
     .trim();

--- a/src/position-mapping/__tests__/position-mapping.test.ts
+++ b/src/position-mapping/__tests__/position-mapping.test.ts
@@ -96,6 +96,15 @@ describe('normalizeAnchorText', () => {
   it('handles empty string', () => {
     expect(normalizeAnchorText('')).toBe('');
   });
+
+  it('keeps CJK letters in heading slugs', () => {
+    expect(normalizeAnchorText('Skills 目录')).toBe('skills-目录');
+    expect(normalizeAnchorText('skills-目录')).toBe('skills-目录');
+  });
+
+  it('decodes percent-encoded CJK fragments', () => {
+    expect(normalizeAnchorText('skills-%E7%9B%AE%E5%BD%95')).toBe('skills-目录');
+  });
 });
 
 describe('normalizeToLF', () => {


### PR DESCRIPTION
## Summary
- Decode percent-encoded markdown hrefs so `link%20test.md` opens `link test.md` instead of a literal `%20` filename.
- Keep Unicode letters in heading slugs and split CRLF so same-document links like `#skills-目录` find `## Skills 目录` on Windows.
- Split `file.md#heading` so the fragment is not treated as part of the filename (also covers #140).

Fixes #160
Fixes #140

## Test plan
- [ ] Ctrl+Click `[a](link%20test.md)` next to a real file named `link test.md`; the file opens.
- [ ] In a CRLF markdown file, Ctrl+Click `[目录](#skills-目录)` with heading `## Skills 目录`; the editor jumps to that heading.
- [ ] Ctrl+Click `[x](./foo.md#test)`; it opens `foo.md` and jumps to the heading (regression for #140).
- [ ] `npx vitest run src/position-mapping/__tests__/position-mapping.test.ts src/commands/__tests__/navigate-to-anchor.test.ts src/link-targets/__tests__/link-targets.test.ts`

Made with [Cursor](https://cursor.com)